### PR TITLE
Add script to register domains en masse

### DIFF
--- a/script/register-domains.sh
+++ b/script/register-domains.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+domains=("$@")
+registrant="FirstName=Steve,LastName=Marshall,ContactType=PUBLIC_BODY,OrganizationName=Ministry of Justice,AddressLine1=102 Petty France,City=London,CountryCode=GB,ZipCode=SW1H 9AJ,Email=domains@digital.justice.gov.uk,PhoneNumber=+44.2033343555,ExtraParams=[{Name=UK_CONTACT_TYPE,Value=GOV}]"
+
+for domain in "${domains[@]}"; do
+  availability=$(aws route53domains check-domain-availability \
+    --domain-name "$domain" --region us-east-1 \
+    | jq -r '.Availability')
+  if [[ 'AVAILABLE' == "$availability" ]]; then
+    echo "$domain is available, registering"
+    aws route53domains register-domain \
+      --region us-east-1 \
+      --domain-name "$domain"  --duration-in-years 1 \
+      --admin-contact "$registrant" \
+      --registrant-contact "$registrant" \
+      --tech-contact "$registrant"
+  else
+    echo "$domain is not available"
+  fi
+done


### PR DESCRIPTION
Sometimes we need to register a bunch of domains, all at once. This script allows us to do that with AWS.