### PR TITLE
Add defense of courtsandtribunals domains

### DIFF
--- a/defensive-domains/domains.mk
+++ b/defensive-domains/domains.mk
@@ -146,6 +146,15 @@ DEFENSIVE_DOMAINS+= \
   tribunals-service.net \
   tribunals-service.uk
 
+# courtsandtribunals
+DEFENSIVE_DOMAINS+= \
+  courtsandtribunals.com \
+  courtsandtribunals.co.uk \
+  courtsandtribunals.org \
+  courtsandtribunals.org.uk \
+  courtsandtribunals.net
+  # Can't get .uk
+
 # hermajestyscourtservice
 DEFENSIVE_DOMAINS+= \
   hermajestyscourtservice.com \


### PR DESCRIPTION
`courtsandtribunals.uk` was used to impersonate the Judicial Appointments Commission, so register all of its siblings. We can't get hold of it right now because the cost is a little prohibitive.