### PR TITLE
Defend Sentencing Council domains

### DIFF
--- a/defensive-domains/domains.mk
+++ b/defensive-domains/domains.mk
@@ -433,3 +433,19 @@ DEFENSIVE_DOMAINS+= \
   youth-justice-board.org \
   youth-justice-board.net \
   youth-justice-board.uk
+
+# sentencingcouncil
+DEFENSIVE_DOMAINS+= \
+  sentencingcouncil.com \
+  sentencingcouncil.co.uk \
+  sentencingcouncil.org \
+  sentencingcouncil.net \
+  sentencingcouncil.uk
+
+# sentencing-council
+DEFENSIVE_DOMAINS+= \
+  sentencing-council.com \
+  sentencing-council.co.uk \
+  sentencing-council.org \
+  sentencing-council.net \
+  sentencing-council.uk


### PR DESCRIPTION
The [Sentencing Council](http://www.sentencing-council.org.uk) were recently subject to an attempted impersonation attack, so this adds a number of similar domains to our defensive estate.

Notably, this excludes .org.uk as they own (and use) both sentencingcouncil.org.uk and sentencing-council.org.uk (as well as using sentencingcouncil.gov.uk for email).