### PR TITLE
Make defensive DNS template contents valid records

### DIFF
--- a/defensive-domains/dns.tmpl.yaml
+++ b/defensive-domains/dns.tmpl.yaml
@@ -22,4 +22,4 @@
 # Null DMARC
 _dmarc:
   type: TXT
-  value: v=DMARC1;p=reject;sp=reject;rua=mailto:dmarc-rua@dmarc.service.gov.uk\;
+  value: v=DMARC1\;p=reject\;sp=reject\;rua=mailto:dmarc-rua@dmarc.service.gov.uk\;


### PR DESCRIPTION
The semicolons in this line need need to be escaped because [semicolons
are comment markers in zone files](https://serverfault.com/questions/743789/why-do-i-need-to-escape-with-in-a-dns-dkim-record/743810#743810), and this value ultimately ends up as part of a zone file.

This mistake wasn't caught because we didn't have tests set up to run on pull requests.