### PR TITLE
Removing court-service.uk

### DIFF
--- a/defensive-domains/domains.mk
+++ b/defensive-domains/domains.mk
@@ -76,8 +76,7 @@ DEFENSIVE_DOMAINS+= \
 DEFENSIVE_DOMAINS+= \
   court-service.org.uk \
   court-service.org \
-  court-service.net \
-  court-service.uk
+  court-service.net
 
 # courts-service
 DEFENSIVE_DOMAINS+= \


### PR DESCRIPTION
Removing court-service.uk from defensive domains as this is a domain that we don't actually own.