### PR TITLE
Remove ima-citizensrights.eu

### DIFF
--- a/defensive-domains/domains.mk
+++ b/defensive-domains/domains.mk
@@ -405,7 +405,6 @@ DEFENSIVE_DOMAINS+= \
   ima-citizensrights.co.uk \
   ima-citizensrights.co.uk \
   ima-citizensrights.com \
-  ima-citizensrights.eu \
   ima-citizensrights.net \
   ima-citizensrights.org \
   ima-citizensrights.uk \


### PR DESCRIPTION
ima-citizensrights.eu removed from defensive domains list as we can no longer own in accordance with new rules around domains following departure from the European Union.