### PR TITLE
Remove cjsdigital.org from list of domains

### DIFF
--- a/defensive-domains/domains.mk
+++ b/defensive-domains/domains.mk
@@ -454,7 +454,3 @@ DEFENSIVE_DOMAINS+= \
   test-ho-nfd.co.uk \
   preprod-ho-nfd.com \
   preprod-ho-nfd.co.uk
-
-# cjsdigital.org
-DEFENSIVE_DOMAINS+= \
-  cjsdigital.org


### PR DESCRIPTION
Domain is actually is use so DNS records have been reinstated and domain is no longer for defensive purposes.