### PR TITLE
:green_heart: Add CICD trigger on config changes only

### DIFF
--- a/.github/workflows/dry-run.yaml
+++ b/.github/workflows/dry-run.yaml
@@ -3,6 +3,9 @@ name: OctoDNS Dry Run
 on:
   workflow_dispatch:
   pull_request:
+    paths:
+      - "hostedzones/**"
+      - "config.yaml"
     branches:
       - main
 

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -3,6 +3,9 @@ name: OctoDNS Sync
 on:
   workflow_dispatch:
   push:
+    paths:
+      - "hostedzones/**"
+      - "config.yaml"
     branches:
       - main
 


### PR DESCRIPTION
This commit will ignore changes that don't require the cicd pipeline to trigger. The reason for this is the sync and apply commands are faily expensive (computationally). By only triggering when octodns config changes or a change to one of our records, we save unnecessary api calls.
