### PR TITLE
:recycle: Remove the EDITOR environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-EDITOR ?= vim
 CONFIG_FILE ?= config.yaml
 ZONES_DIR ?= hostedzones
 


### PR DESCRIPTION
This is too opinionated and should be left to the user to set.
