### PR TITLE
:green_heart: Output the unmanaged hostedzone in stdout

### DIFF
--- a/.github/workflows/check-unmanaged-zones.yaml
+++ b/.github/workflows/check-unmanaged-zones.yaml
@@ -25,15 +25,27 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.OCTODNS_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.OCTODNS_AWS_SECRET_ACCESS_KEY }}
+          PYTHONUNBUFFERED: 1
         run: |
-          output=$(make check-unmanaged-zones)
+          echo "Running check for unmanaged zones..."
+          output=$(make check-unmanaged-zones 2>&1)
+          echo "$output"
           echo "check_output<<EOF" >> $GITHUB_OUTPUT
           echo "$output" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+          if echo "$output" | grep -q "not managed by octoDNS"; then
+            echo "unmanaged_zones_found=true" >> $GITHUB_OUTPUT
+          else
+            echo "unmanaged_zones_found=false" >> $GITHUB_OUTPUT
+          fi
+          # Exit with non-zero status if unmanaged zones are found
+          if echo "$output" | grep -q "not managed by octoDNS"; then
+            exit 1
+          fi
 
       - name: Send notification to Slack
-        if: failure() || contains(steps.check-zones.outputs.check_output, 'not managed by octoDNS')
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 #v1.24.0
+        if: failure()
         with:
           payload: |
             {
@@ -85,4 +97,3 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-


### PR DESCRIPTION
Currently, the github action simply fails with a make error code. This change should enable Python to write to stdout, making it easier for someone to identify which zone has been added illegally.
