### PR TITLE
🌐 Print "Empty" Route53 Hosted Zones

### DIFF
--- a/.github/workflows/check-empty-zones.yaml
+++ b/.github/workflows/check-empty-zones.yaml
@@ -1,0 +1,27 @@
+name: Print out empty hosted zones # A hosted zone with only an NS and SOA record
+
+on:
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  check-for-empty-zones:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: |
+          make install
+
+      - name: Run check for unmanaged zones
+        id: check-zones
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.OCTODNS_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OCTODNS_AWS_SECRET_ACCESS_KEY }}
+          PYTHONUNBUFFERED: 1
+        run: make check-empty-zones

--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,18 @@ endef
 
 help:
 	@echo "Available commands:"
+	@echo "  make check-empty-zones    - Run check for empty zones"
+	@echo "  make clean                - Clean up generated files"
+	@echo "  make compare-zone zone=<zone> - Compare a zone file with its live configuration"
+	@echo "  make dump-zone zone=<zone> - Dump the current live configuration for a zone"
+	@echo "  make edit-zone zone=<zone> - Edit a hosted zone file"
 	@echo "  make help                 - Show this help message"
 	@echo "  make install              - Set up the Python environment"
-	@echo "  make edit-zone zone=<zone> - Edit a hosted zone file"
-	@echo "  make validate-zones       - Validate all zone files"
-	@echo "  make sync-dry-run         - Perform a dry-run sync for all zones"
-	@echo "  make sync-apply           - Apply changes to all zones"
 	@echo "  make list-zones           - List all zones"
-	@echo "  make dump-zone zone=<zone> - Dump the current live configuration for a zone"
-	@echo "  make compare-zone zone=<zone> - Compare a zone file with its live configuration"
-	@echo "  make clean                - Clean up generated files"
+	@echo "  make sync-apply           - Apply changes to all zones"
+	@echo "  make sync-dry-run         - Perform a dry-run sync for all zones"
 	@echo "  make test                 - Run the test suite"
+	@echo "  make validate-zones       - Validate all zone files"
 
 install:
 	python3 -m venv venv
@@ -88,6 +89,10 @@ compare-zone:
 check-unmanaged-zones: install
 	$(call check_aws_creds)
 	@. venv/bin/activate && python3 check_unmanaged_zones.py
+
+check-empty-zones: install
+	$(call check_aws_creds)
+	@. venv/bin/activate && python3 check_empty_zones.py
 
 clean:
 	@rm -rf venv tmp

--- a/check_empty_zones.py
+++ b/check_empty_zones.py
@@ -1,0 +1,46 @@
+import sys
+
+import boto3
+
+
+def get_aws_zones():
+    route53 = boto3.client("route53")
+    zones = []
+    paginator = route53.get_paginator("list_hosted_zones")
+    for page in paginator.paginate():
+        for zone in page["HostedZones"]:
+            zones.append((zone["Id"], zone["Name"]))
+    return zones
+
+
+def is_zone_empty(zone_id):
+    route53 = boto3.client("route53")
+    paginator = route53.get_paginator("list_resource_record_sets")
+    for page in paginator.paginate(HostedZoneId=zone_id):
+        for record_set in page["ResourceRecordSets"]:
+            # Ignore NS and SOA records as they are default
+            if record_set["Type"] not in ["NS", "SOA"]:
+                return False
+    return True
+
+
+def main():
+    print("Checking for empty hosted zones...")
+    empty_zones = []
+    for zone_id, zone_name in get_aws_zones():
+        if is_zone_empty(zone_id):
+            # Remove trailing dot from zone name
+            empty_zones.append(zone_name.rstrip("."))
+
+    if empty_zones:
+        print("The following hosted zones are empty:")
+        for zone in empty_zones:
+            print(f"  - {zone}")
+        sys.exit(1)
+    else:
+        print("No empty hosted zones found.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_check_for_empty_zones.py
+++ b/tests/test_check_for_empty_zones.py
@@ -1,0 +1,96 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from check_empty_zones import get_aws_zones, is_zone_empty, main
+
+
+@pytest.fixture
+def mock_boto3_client():
+    with patch('boto3.client') as mock_client:
+        yield mock_client
+
+
+def test_get_aws_zones(mock_boto3_client):
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.return_value = [
+        {
+            'HostedZones': [
+                {'Id': '/hostedzone/Z1234567890ABC', 'Name': 'example.com.'},
+                {'Id': '/hostedzone/Z0987654321DEF', 'Name': 'test.com.'}
+            ]
+        }
+    ]
+    mock_boto3_client.return_value.get_paginator.return_value = mock_paginator
+
+    result = get_aws_zones()
+    assert result == [
+        ('/hostedzone/Z1234567890ABC', 'example.com.'),
+        ('/hostedzone/Z0987654321DEF', 'test.com.')
+    ]
+
+
+def test_is_zone_empty_true(mock_boto3_client):
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.return_value = [
+        {
+            'ResourceRecordSets': [
+                {'Type': 'NS'},
+                {'Type': 'SOA'}
+            ]
+        }
+    ]
+    mock_boto3_client.return_value.get_paginator.return_value = mock_paginator
+
+    assert is_zone_empty('dummy_zone_id') == True
+
+
+def test_is_zone_empty_false(mock_boto3_client):
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.return_value = [
+        {
+            'ResourceRecordSets': [
+                {'Type': 'NS'},
+                {'Type': 'SOA'},
+                {'Type': 'A'}
+            ]
+        }
+    ]
+    mock_boto3_client.return_value.get_paginator.return_value = mock_paginator
+
+    assert is_zone_empty('dummy_zone_id') == False
+
+
+@patch('check_empty_zones.get_aws_zones')
+@patch('check_empty_zones.is_zone_empty')
+def test_main_empty_zones(mock_is_zone_empty, mock_get_aws_zones, capsys):
+    mock_get_aws_zones.return_value = [
+        ('/hostedzone/Z1234567890ABC', 'example.com.'),
+        ('/hostedzone/Z0987654321DEF', 'test.com.')
+    ]
+    mock_is_zone_empty.side_effect = [True, False]
+
+    with pytest.raises(SystemExit) as e:
+        main()
+
+    assert e.value.code == 1
+    captured = capsys.readouterr()
+    assert "The following hosted zones are empty:" in captured.out
+    assert "  - example.com" in captured.out
+    assert "  - test.com" not in captured.out
+
+
+@patch('check_empty_zones.get_aws_zones')
+@patch('check_empty_zones.is_zone_empty')
+def test_main_no_empty_zones(mock_is_zone_empty, mock_get_aws_zones, capsys):
+    mock_get_aws_zones.return_value = [
+        ('/hostedzone/Z1234567890ABC', 'example.com.'),
+        ('/hostedzone/Z0987654321DEF', 'test.com.')
+    ]
+    mock_is_zone_empty.return_value = False
+
+    with pytest.raises(SystemExit) as e:
+        main()
+
+    assert e.value.code == 0
+    captured = capsys.readouterr()
+    assert "No empty hosted zones found." in captured.out


### PR DESCRIPTION
## 👀 Purpose

- This PR will add a new procedural script that reports on Hosted Zones with ONLY an SOA and NS record.
- It is understood that at this point, either the zone is incorrectly configured or should be considered for removal.
- I don't want to add an alarm just yet, but this would be useful as a script that can be triggered by anyone in the organisation.

## ♻️ What's changed

- A new script that checks R53 for hosted zones with only an SOA and NS record.
- A makefile command with a help entry for quick and easy execution.
- A test file that ensures the script performs as expected.
- A GitHub Action that will trigger the script with the required IAM permissions.


## 📝 Notes

- This PR also contains a small formatting change to the makefile's help argument. It simply sorts the entries for improved readability.