### PR TITLE
:recycle: Add quiet mode to validate and document it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ edit-zone:
 
 validate-zones:
 	$(call check_aws_creds)
-	octodns-validate --config-file=$(CONFIG_FILE)
+	octodns-validate --config-file=$(CONFIG_FILE) --quiet
 
 sync-dry-run:
 	$(call check_aws_creds)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Ensure your AWS credentials have the necessary permissions to manage Route53 hos
 5. Ensure changes are made in alphabetical order within the file.
 
 6. Validate your changes:
+
+:memo: **Note:** This may look a little messy, but you're looking for errors rather than warnings.
    ```bash
    make validate-zones
    ```


### PR DESCRIPTION
When running validate to change a hosted zones records, it's important not to error on things we don't care about (warnings like . at the end of a record). We do however want early feedback about things like incorrect yaml positions.
