### PR TITLE
Add CNAME for exchange-integration-services-stream.service.justice.go…

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -99,6 +99,10 @@ _cd274e7ee824297d08388d398a2b2b8a.crown-court-remuneration:
   ttl: 300
   type: CNAME
   value: _b2d6197bf0aa1d024b5fef68a13127bb.fpwkmzyskh.acm-validations.aws.
+_d0056e0292b63e43ee7490de450c6111.exchange-integration-services-stream
+  ttl: 300
+  type: CNAME
+  value: 3f666b6b9cd8ac0bd8ab145b89b2aa87.e449af38df4aa2fe9b1656cad6f70ea9.fcdbccead55470275a70.sectigo.com.
 _d8e015eb77621a22d1bb4fe339ec1ebd.dev.manage-external-funded-offender-provision:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR add a CNAME validation record for the gandi.net certificate for exchange-integration-services-stream.service.justice.gov.uk

## ♻️ What's changed

- Adds CNAME record _D0056E0292B63E43EE7490DE450C6111.exchange-integration-services-stream.service.justice.gov.uk