### PR TITLE
:wrench: Increase retries when applying route53 record changes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,7 @@ providers:
     enforce_order: True
   route53:
     class: octodns_route53.Route53Provider
+    client_max_attempts: 10
     access_key_id: env/AWS_ACCESS_KEY_ID
     secret_access_key: env/AWS_SECRET_ACCESS_KEY
 


### PR DESCRIPTION
OctoDNS/boto sometimes has an issue withe retrying against the Route53
API. This change increases the
number of attempts that we retry by increasing the
`client_max_attempts`from the default of 4.
