### PR TITLE
Remove dangling CNAME

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -1243,10 +1243,6 @@ locateaprison:
   ttl: 600
   type: A
   value: 85.133.48.165
-lyncdiscover:
-  ttl: 600
-  type: CNAME
-  value: webdir.online.lync.com.
 lyncdiscover.cshrcasework:
   type: CNAME
   value: webdir.online.lync.com


### PR DESCRIPTION
## 👀 Purpose

- This PR removes dangling DNS records reported by CDDO to domains@digital.justice.gov.uk on 2nd July 2024.

## ♻️ What's changed

Removed the following CNAMES from justice.gov.uk hostedzone
- lyncdiscover.justice.gov.uk