### PR TITLE
Remove dangling CNAME

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -802,10 +802,6 @@ design102:
 - ttl: 300
   type: TXT
   value: v=spf1 ip4:78.31.110.246  -all
-desktop.cshrcasework:
-  ttl: 300
-  type: CNAME
-  value: moj.fw-daas.com
 dev:
   ttl: 86400
   type: NS


### PR DESCRIPTION
## 👀 Purpose

- This PR removes dangling DNS records reported by CDDO to domains@digital.justice.gov.uk on 2nd July 2024.

## ♻️ What's changed

Removed the following CNAMES from justice.gov.uk hostedzone
- `desktop.cshrcasework.justice.gov.uk`