### PR TITLE
Delete hostedzone 253.33.194.in-addr.arpa.yaml

### DIFF
--- a/hostedzones/253.33.194.in-addr.arpa.yaml
+++ b/hostedzones/253.33.194.in-addr.arpa.yaml
@@ -1,9 +1,0 @@
----
-? ''
-: ttl: 172800
-  type: NS
-  values:
-  - ns-1169.awsdns-18.org.
-  - ns-164.awsdns-20.com.
-  - ns-1960.awsdns-53.co.uk.
-  - ns-672.awsdns-20.net.


### PR DESCRIPTION
## 👀 Purpose

- This PR removes the hostedzone for 253.33.194.in-addr.arpa, which is no longer in use. It meets the criteria for deletion.

## ♻️ What's changed

- Delete 253.33.194.in-addr.arpa.yaml