### PR TITLE
Updated-DNS-Record

### DIFF
--- a/hostedzones/247rapesupport.org.uk.yaml
+++ b/hostedzones/247rapesupport.org.uk.yaml
@@ -1,9 +1,34 @@
 ---
 ? ''
-: ttl: 172800
-  type: NS
-  values:
-  - ns-1230.awsdns-25.org.
-  - ns-2027.awsdns-61.co.uk.
-  - ns-230.awsdns-28.com.
-  - ns-612.awsdns-12.net.
+: - ttl: 300
+    type: CAA
+    values:
+    - flags: 0
+      tag: iodef
+      value: mailto:certificates@digital.justice.gov.uk
+    - flags: 0
+      tag: issue
+      value: ;
+  - ttl: 300
+    type: MX
+    value:
+      exchange: .
+      preference: 0
+  - ttl: 172800
+    type: NS
+    values:
+    - ns-1230.awsdns-25.org.
+    - ns-2027.awsdns-61.co.uk.
+    - ns-230.awsdns-28.com.
+    - ns-612.awsdns-12.net.
+  - ttl: 300
+    type: TXT
+    value: v=spf1 -all
+'*._domainkey':
+  ttl: 300
+  type: TXT
+  value: v=DKIM1\; p=
+_dmarc:
+  ttl: 300
+  type: TXT
+  value: v=DMARC1\;p=reject\;sp=reject\;rua=mailto:dmarc-rua@dmarc.service.gov.uk\;

--- a/hostedzones/247rapesupport.org.uk.yaml
+++ b/hostedzones/247rapesupport.org.uk.yaml
@@ -1,14 +1,14 @@
 ---
-? ''
-: - ttl: 300
+'':
+  - ttl: 300
     type: CAA
     values:
-    - flags: 0
-      tag: iodef
-      value: mailto:certificates@digital.justice.gov.uk
-    - flags: 0
-      tag: issue
-      value: ;
+      - flags: 0
+        tag: iodef
+        value: mailto:certificates@digital.justice.gov.uk
+      - flags: 0
+        tag: issue
+        value: ';'
   - ttl: 300
     type: MX
     value:
@@ -17,10 +17,10 @@
   - ttl: 172800
     type: NS
     values:
-    - ns-1230.awsdns-25.org.
-    - ns-2027.awsdns-61.co.uk.
-    - ns-230.awsdns-28.com.
-    - ns-612.awsdns-12.net.
+      - ns-1230.awsdns-25.org.
+      - ns-2027.awsdns-61.co.uk.
+      - ns-230.awsdns-28.com.
+      - ns-612.awsdns-12.net.
   - ttl: 300
     type: TXT
     value: v=spf1 -all

--- a/hostedzones/brookhouseinvestigation.independent.gov.uk.yaml
+++ b/hostedzones/brookhouseinvestigation.independent.gov.uk.yaml
@@ -1,3 +1,4 @@
+---
 - ttl: 172800
   type: NS
   values:

--- a/hostedzones/brookhouseinvestigation.independent.gov.uk.yaml
+++ b/hostedzones/brookhouseinvestigation.independent.gov.uk.yaml
@@ -1,9 +1,32 @@
----
-? ''
-: ttl: 172800
+- ttl: 172800
   type: NS
   values:
-  - ns-1361.awsdns-42.org.
-  - ns-1704.awsdns-21.co.uk.
-  - ns-360.awsdns-45.com.
-  - ns-538.awsdns-03.net.
+    - ns-1361.awsdns-42.org.
+    - ns-1704.awsdns-21.co.uk.
+    - ns-360.awsdns-45.com.
+    - ns-538.awsdns-03.net.
+- ttl: 300
+  type: CAA
+  values:
+    - flags: 0
+      tag: issue
+      value: ";"
+    - flags: 0
+      tag: iodef
+      value: mailto:certificates@digital.justice.gov.uk
+- ttl: 300
+  type: MX
+  value:
+    exchange: .
+    preference: 0
+- ttl: 300
+  type: TXT
+  value: v=spf1 -all
+- ttl: 300
+  type: TXT
+  name: "*._domainkey"
+  value: v=DKIM1\; p=
+- ttl: 300
+  type: TXT
+  name: _dmarc
+  value: v=DMARC1\; p=reject\; rua=mailto:dmarc-rua@dmarc.service.gov.uk

--- a/hostedzones/cjsm.co.uk.yaml
+++ b/hostedzones/cjsm.co.uk.yaml
@@ -1,9 +1,34 @@
 ---
 ? ''
-: ttl: 172800
-  type: NS
-  values:
-  - ns-1308.awsdns-35.org.
-  - ns-1866.awsdns-41.co.uk.
-  - ns-266.awsdns-33.com.
-  - ns-845.awsdns-41.net.
+: - ttl: 300
+    type: CAA
+    values:
+    - flags: 0
+      tag: iodef
+      value: mailto:certificates@digital.justice.gov.uk
+    - flags: 0
+      tag: issue
+      value: ;
+  - ttl: 300
+    type: MX
+    value:
+      exchange: .
+      preference: 0
+  - ttl: 172800
+    type: NS
+    values:
+    - ns-1308.awsdns-35.org.
+    - ns-1866.awsdns-41.co.uk.
+    - ns-266.awsdns-33.com.
+    - ns-845.awsdns-41.net.
+  - ttl: 300
+    type: TXT
+    value: v=spf1 -all
+'*._domainkey':
+  ttl: 300
+  type: TXT
+  value: v=DKIM1\; p=
+_dmarc:
+  ttl: 300
+  type: TXT
+  value: v=DMARC1\;p=reject\;sp=reject\;rua=mailto:dmarc-rua@dmarc.service.gov.uk\;

--- a/hostedzones/criminal-justice.royal-commission.uk.yaml
+++ b/hostedzones/criminal-justice.royal-commission.uk.yaml
@@ -1,9 +1,34 @@
 ---
 ? ''
-: ttl: 172800
-  type: NS
-  values:
-  - ns-1213.awsdns-23.org.
-  - ns-1799.awsdns-32.co.uk.
-  - ns-466.awsdns-58.com.
-  - ns-673.awsdns-20.net.
+: - ttl: 300
+    type: CAA
+    values:
+    - flags: 0
+      tag: iodef
+      value: mailto:certificates@digital.justice.gov.uk
+    - flags: 0
+      tag: issue
+      value: ;
+  - ttl: 300
+    type: MX
+    value:
+      exchange: .
+      preference: 0
+  - ttl: 172800
+    type: NS
+    values:
+    - ns-1213.awsdns-23.org.
+    - ns-1799.awsdns-32.co.uk.
+    - ns-466.awsdns-58.com.
+    - ns-673.awsdns-20.net.
+  - ttl: 300
+    type: TXT
+    value: v=spf1 -all
+'*._domainkey':
+  ttl: 300
+  type: TXT
+  value: v=DKIM1\; p=
+_dmarc:
+  ttl: 300
+  type: TXT
+  value: v=DMARC1\;p=reject\;sp=reject\;rua=mailto:dmarc-rua@dmarc.service.gov.uk\;

--- a/hostedzones/independentpublicadvocate.org.uk.yaml
+++ b/hostedzones/independentpublicadvocate.org.uk.yaml
@@ -1,9 +1,33 @@
 ---
 ? ''
-: ttl: 172800
-  type: NS
-  values:
-  - ns-1190.awsdns-20.org.
-  - ns-1712.awsdns-22.co.uk.
-  - ns-37.awsdns-04.com.
-  - ns-532.awsdns-02.net.
+: - ttl: 300
+    type: CAA
+    values:
+    - flags: 0
+      tag: iodef
+      value: mailto:certificates@digital.justice.gov.uk
+    - flags: 0
+      tag: issue
+      value: ;
+  - ttl: 300
+    type: MX
+    value:
+      exchange: .
+      preference: 0
+  - ttl: 172800
+    type: NS
+    values:
+    - ns-1712.awsdns-22.co.uk.
+    - ns-37.awsdns-04.com.
+    - ns-532.awsdns-02.net.
+  - ttl: 300
+    type: TXT
+    value: v=spf1 -all
+'*._domainkey':
+  ttl: 300
+  type: TXT
+  value: v=DKIM1\; p=
+_dmarc:
+  ttl: 300
+  type: TXT
+  value: v=DMARC1\;p=reject\;sp=reject\;rua=mailto:dmarc-rua@dmarc.service.gov.uk\;


### PR DESCRIPTION
Added defensive DNS records to specified domains for enhanced security.

DNS records including CAA, MX, and TXT have been added to the following hosted zones:

1.brookhouseinvestigation.independent.gov.uk
2.criminal-justice.royal-commission.uk
3.247rapesupport.org.uk
4.cjsm.co.uk
5.independentpublicadvocate.org.uk

Enhance domain protection and reduce exposure to potential security threats by implementing recommended defensive DNS configurations.



