### PR TITLE
Remove dangling CNAMES

### DIFF
--- a/hostedzones/judiciary.gov.uk.yaml
+++ b/hostedzones/judiciary.gov.uk.yaml
@@ -134,10 +134,6 @@ smtp:
   ttl: 600
   type: A
   value: 80.86.35.81
-uat.residential-property:
-  ttl: 600
-  type: CNAME
-  value: uat.rpts.clients.wtg.co.uk.
 webapps:
   ttl: 600
   type: NS
@@ -150,10 +146,6 @@ www:
   ttl: 600
   type: CNAME
   value: redirect.dxw.net
-www.residential-property:
-  ttl: 600
-  type: CNAME
-  value: prod.rpts.clients.wtg.co.uk.
 www.sec:
   ttl: 600
   type: A


### PR DESCRIPTION
## 👀 Purpose

- This PR removes dangling DNS records reported by CDDO to domains@digital.justice.gov.uk on 2nd July 2024.

## ♻️ What's changed

Removes the following CNAMES from judiciary.gov.uk hostedzone
- `uat.residential-property.judiciary.gov.uk`
- `www.residential-property.judiciary.gov.uk`