### PR TITLE
:sparkles: Add Defensive Domains to the 247rapesupport hostedzone

### DIFF
--- a/hostedzones/247rapesupport.org.uk.yaml
+++ b/hostedzones/247rapesupport.org.uk.yaml
@@ -1,9 +1,34 @@
 ---
-? ''
-: ttl: 172800
-  type: NS
-  values:
-  - ns-1230.awsdns-25.org.
-  - ns-2027.awsdns-61.co.uk.
-  - ns-230.awsdns-28.com.
-  - ns-612.awsdns-12.net.
+"":
+  - ttl: 300
+    type: CAA
+    values:
+      - flags: 0
+        tag: iodef
+        value: mailto:certificates@digital.justice.gov.uk
+      - flags: 0
+        tag: issue
+        value: ;
+  - ttl: 300
+    type: MX
+    value:
+      exchange: .
+      preference: 0
+  - ttl: 172800
+    type: NS
+    values:
+      - ns-1230.awsdns-25.org.
+      - ns-2027.awsdns-61.co.uk.
+      - ns-230.awsdns-28.com.
+      - ns-612.awsdns-12.net.
+  - ttl: 300
+    type: TXT
+    value: v=spf1 -all
+"*._domainkey":
+  ttl: 300
+  type: TXT
+  value: v=DKIM1\; p=
+_dmarc:
+  ttl: 300
+  type: TXT
+  value: v=DMARC1\;p=reject\;sp=reject\;rua=mailto:dmarc-rua@dmarc.service.gov.uk\;


### PR DESCRIPTION
This was identified in a recent daily check and requires defensive domains.
