### PR TITLE
:wrench: Add --quiet argument to ignore INFO output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ validate-zones:
 
 sync-dry-run:
 	$(call check_aws_creds)
-	octodns-sync --config-file=$(CONFIG_FILE)
+	octodns-sync --config-file=$(CONFIG_FILE) --quiet
 
 sync-apply:
 	$(call check_aws_creds)


### PR DESCRIPTION
The output is already very verbose. This should help, but it won't eliminate the requirement to scroll past 1000K + lines of warnings.