### PR TITLE
:fire: Remove the "on pull-request" trigger

### DIFF
--- a/.github/workflows/remove-sectigo-blocks.yaml
+++ b/.github/workflows/remove-sectigo-blocks.yaml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 0 * * 1-5" # Runs at 00:00 from Monday to Friday
   workflow_dispatch: # Allows manual triggering
-  pull_request:
 
 jobs:
   remove_sectigo_blocks:


### PR DESCRIPTION
I think this was accidental and should be triggered either manually or at a set time.
