### PR TITLE
cjsm-dns-update

### DIFF
--- a/hostedzones/cjsm.co.uk.yaml
+++ b/hostedzones/cjsm.co.uk.yaml
@@ -1,9 +1,34 @@
 ---
-? ''
-: ttl: 172800
-  type: NS
-  values:
-  - ns-1308.awsdns-35.org.
-  - ns-1866.awsdns-41.co.uk.
-  - ns-266.awsdns-33.com.
-  - ns-845.awsdns-41.net.
+"":
+  - ttl: 300
+    type: CAA
+    values:
+      - flags: 0
+        tag: iodef
+        value: mailto:certificates@digital.justice.gov.uk
+      - flags: 0
+        tag: issue
+        value: ;
+  - ttl: 300
+    type: MX
+    value:
+      exchange: .
+      preference: 0
+  - ttl: 172800
+    type: NS
+    values:
+      - ns-1308.awsdns-35.org.
+      - ns-1866.awsdns-41.co.uk.
+      - ns-266.awsdns-33.com.
+      - ns-845.awsdns-41.net.
+  - ttl: 300
+    type: TXT
+    value: v=spf1 -all
+"*._domainkey":
+  ttl: 300
+  type: TXT
+  value: v=DKIM1\; p=
+_dmarc:
+  ttl: 300
+  type: TXT
+  value: v=DMARC1\;p=reject\;sp=reject\;rua=mailto:dmarc-rua@dmarc.service.gov.uk\;


### PR DESCRIPTION
Add defensive DNS records for enhanced domain security 
For --cjsm.co.uk
Added --  CAA, MX and TXT records.