### PR TITLE
hostedzone-yaml-recomendation

### DIFF
--- a/hostedzones/independentpublicadvocate.org.uk.yaml
+++ b/hostedzones/independentpublicadvocate.org.uk.yaml
@@ -1,9 +1,34 @@
 ---
-? ''
-: ttl: 172800
-  type: NS
-  values:
-  - ns-1190.awsdns-20.org.
-  - ns-1712.awsdns-22.co.uk.
-  - ns-37.awsdns-04.com.
-  - ns-532.awsdns-02.net.
+"":
+  - ttl: 300
+    type: CAA
+    values:
+      - flags: 0
+        tag: iodef
+        value: mailto:certificates@digital.justice.gov.uk
+      - flags: 0
+        tag: issue
+        value: ;
+  - ttl: 300
+    type: MX
+    value:
+      exchange: .
+      preference: 0
+  - ttl: 172800
+    type: NS
+    values:
+      - ns-1018.awsdns-63.net.
+      - ns-1254.awsdns-28.org.
+      - ns-129.awsdns-16.com.
+      - ns-1848.awsdns-39.co.uk.
+  - ttl: 300
+    type: TXT
+    value: v=spf1 -all
+"*._domainkey":
+  ttl: 300
+  type: TXT
+  value: v=DKIM1\; p=
+_dmarc:
+  ttl: 300
+  type: TXT
+  value: v=DMARC1\;p=reject\;sp=reject\;rua=mailto:dmarc-rua@dmarc.service.gov.uk\;

--- a/hostedzones/independentpublicadvocate.org.uk.yaml
+++ b/hostedzones/independentpublicadvocate.org.uk.yaml
@@ -20,7 +20,7 @@
       - ns-1190.awsdns-20.org.
       - ns-1712.awsdns-22.co.uk.
       - ns-37.awsdns-04.com.
-      - ns-532.awsdns-02.co.net.
+      - ns-532.awsdns-02.net.
   - ttl: 300
     type: TXT
     value: v=spf1 -all

--- a/hostedzones/independentpublicadvocate.org.uk.yaml
+++ b/hostedzones/independentpublicadvocate.org.uk.yaml
@@ -17,7 +17,7 @@
   - ttl: 172800
     type: NS
     values:
-      - ns-1190.awsdns-20.org
+      - ns-1190.awsdns-20.org.
       - ns-1712.awsdns-22.co.uk.
       - ns-37.awsdns-04.com.
       - ns-532.awsdns-02.co.net.

--- a/hostedzones/independentpublicadvocate.org.uk.yaml
+++ b/hostedzones/independentpublicadvocate.org.uk.yaml
@@ -17,10 +17,10 @@
   - ttl: 172800
     type: NS
     values:
-      - ns-1018.awsdns-63.net.
-      - ns-1254.awsdns-28.org.
-      - ns-129.awsdns-16.com.
-      - ns-1848.awsdns-39.co.uk.
+      - ns-1190.awsdns-20.org
+      - ns-1712.awsdns-22.co.uk.
+      - ns-37.awsdns-04.com.
+      - ns-532.awsdns-02.co.net.
   - ttl: 300
     type: TXT
     value: v=spf1 -all


### PR DESCRIPTION
Add defensive DNS records for enhanced domain security
For -- independentpublicadvocate.org.uk
Added -- CAA, MX and TXT records.