### PR TITLE
Remove dangling DNS records

### DIFF
--- a/hostedzones/rpts.gov.uk.yaml
+++ b/hostedzones/rpts.gov.uk.yaml
@@ -36,10 +36,6 @@ dev:
   ttl: 1800
   type: A
   value: 193.114.80.13
-ftp:
-  ttl: 600
-  type: CNAME
-  value: prod.rpts.clients.wtg.co.uk.
 test:
   ttl: 1800
   type: A
@@ -48,7 +44,3 @@ uat:
   ttl: 1800
   type: A
   value: 212.28.12.201
-www:
-  ttl: 1800
-  type: CNAME
-  value: prod.rpts.clients.wtg.co.uk.


### PR DESCRIPTION
## 👀 Purpose

- This PR removes dangling DNS records reported by CDDO to domains@digital.justice.gov.uk on 2nd July 2024.

## ♻️ What's changed

Removes the following CNAMES from `rpts.gov.uk` hostedzone
- `ftp.rpts.gov.uk`
- `www.rpts.gov.uk`