### PR TITLE
Added CAA,-MX-TXT-records to the domain criminal-justice.royal-commission.uk

### DIFF
--- a/hostedzones/criminal-justice.royal-commission.uk.yaml
+++ b/hostedzones/criminal-justice.royal-commission.uk.yaml
@@ -1,4 +1,6 @@
-? - ttl: 300
+---
+"":
+  - ttl: 300
     type: CAA
     values:
       - flags: 0
@@ -29,5 +31,4 @@
 _dmarc:
   ttl: 300
   type: TXT
-  value: v=DMARC1\; p=reject\; sp=reject\; rua=mailto:dmarc-rua@dmarc.service.gov.uk\;
-
+  value: v=DMARC1\;p=reject\;sp=reject\;rua=mailto:dmarc-rua@dmarc.service.gov.uk

--- a/hostedzones/criminal-justice.royal-commission.uk.yaml
+++ b/hostedzones/criminal-justice.royal-commission.uk.yaml
@@ -1,9 +1,33 @@
----
-? ''
-: ttl: 172800
-  type: NS
-  values:
-  - ns-1213.awsdns-23.org.
-  - ns-1799.awsdns-32.co.uk.
-  - ns-466.awsdns-58.com.
-  - ns-673.awsdns-20.net.
+? - ttl: 300
+    type: CAA
+    values:
+      - flags: 0
+        tag: iodef
+        value: mailto:certificates@digital.justice.gov.uk
+      - flags: 0
+        tag: issue
+        value: ;
+  - ttl: 300
+    type: MX
+    value:
+      exchange: .
+      preference: 0
+  - ttl: 172800
+    type: NS
+    values:
+      - ns-1213.awsdns-23.org.
+      - ns-1799.awsdns-32.co.uk.
+      - ns-466.awsdns-58.com.
+      - ns-673.awsdns-20.net.
+  - ttl: 300
+    type: TXT
+    value: v=spf1 -all
+"*._domainkey":
+  ttl: 300
+  type: TXT
+  value: v=DKIM1\; p=
+_dmarc:
+  ttl: 300
+  type: TXT
+  value: v=DMARC1\; p=reject\; sp=reject\; rua=mailto:dmarc-rua@dmarc.service.gov.uk\;
+


### PR DESCRIPTION
Added CAA,-MX-TXT-records to the domain criminal-justice.royal-com.

Add defensive DNS records for enhanced domain security
For --criminal-justice.royal-commission.uk
Added -- CAA, MX and TXT records.
Value

Protects domains and reduces risk of security vulnerabilities.