### PR TITLE
Added CAA,MX, and-TXT-records to the domain- brookhouseinvestigation

### DIFF
--- a/hostedzones/brookhouseinvestigation.independent.gov.uk.yaml
+++ b/hostedzones/brookhouseinvestigation.independent.gov.uk.yaml
@@ -32,4 +32,3 @@ _dmarc:
   ttl: 300
   type: TXT
   value: v=DMARC1\;p=reject\;sp=reject\;rua=mailto:dmarc-rua@dmarc.service.gov.uk\;
-

--- a/hostedzones/brookhouseinvestigation.independent.gov.uk.yaml
+++ b/hostedzones/brookhouseinvestigation.independent.gov.uk.yaml
@@ -1,9 +1,35 @@
 ---
-? ''
-: ttl: 172800
-  type: NS
-  values:
-  - ns-1361.awsdns-42.org.
-  - ns-1704.awsdns-21.co.uk.
-  - ns-360.awsdns-45.com.
-  - ns-538.awsdns-03.net.
+"":
+  - ttl: 300
+    type: CAA
+    values:
+      - flags: 0
+        tag: iodef
+        value: mailto:certificates@digital.justice.gov.uk
+      - flags: 0
+        tag: issue
+        value: ";"
+  - ttl: 300
+    type: MX
+    value:
+      exchange: .
+      preference: 0
+  - ttl: 172800
+    type: NS
+    values:
+      - ns-1361.awsdns-42.org.
+      - ns-1704.awsdns-21.co.uk.
+      - ns-360.awsdns-45.com.
+      - ns-538.awsdns-03.net.
+  - ttl: 300
+    type: TXT
+    value: v=spf1 -all
+"*._domainkey":
+  ttl: 300
+  type: TXT
+  value: v=DKIM1\; p=
+_dmarc:
+  ttl: 300
+  type: TXT
+  value: v=DMARC1\;p=reject\;sp=reject\;rua=mailto:dmarc-rua@dmarc.service.gov.uk\;
+


### PR DESCRIPTION
Added CAA,-MX-TXT-records to the domain brookhouseinvestigation.independent.gov.uk

Add defensive DNS records for enhanced domain security
For -- brookhouseinvestigation.independent.gov.uk
Added -- CAA, MX and TXT records.
Value

Protects domains and reduces risk of security vulnerabilities.