### PR TITLE
Add Miro and Atlassian validation TXT records

### DIFF
--- a/hostedzones/cica.gov.uk.yaml
+++ b/hostedzones/cica.gov.uk.yaml
@@ -26,6 +26,8 @@
     - MS=ms41318437
     - v=spf1 ip4:54.240.0.0/18 include:spf.protection.outlook.com ~all
     - w6xmnnqn2r3vnry0c5n5sg3dg25wvlln
+    - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
+    - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
 _56a37ebc38b8f47a75fe557fc29d22dd.mta-sts:
   ttl: 60
   type: CNAME

--- a/hostedzones/govfsl.com.yaml
+++ b/hostedzones/govfsl.com.yaml
@@ -22,6 +22,8 @@
     - v=spf1 include:_spf.google.com include:carillionplc.com include:spf.protection.outlook.com
       include:spf_c.oracle.com ip4:188.65.119.39 ip4:188.65.119.42 ip4:87.247.244.98
       ip4:195.62.28.68 ip4:185.24.97.25 -all
+    - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
+    - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
 _94027e3232a87bef15c3cfb7834ff05c.mta-sts:
   ttl: 60
   type: CNAME

--- a/hostedzones/hmiprisons.gov.uk.yaml
+++ b/hostedzones/hmiprisons.gov.uk.yaml
@@ -18,6 +18,7 @@
     - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
     - v=spf1 include:_spf.mlsend.com ip4:194.33.196.8/32 ip4:194.33.192.8/32  include:spf.protection.outlook.com
       -all
+    - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
 _asvdns-ee832343-ceef-4fc6-ba97-68aa978af228:
   ttl: 300
   type: TXT

--- a/hostedzones/hmiprobation.gov.uk.yaml
+++ b/hostedzones/hmiprobation.gov.uk.yaml
@@ -18,6 +18,7 @@
     - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
     - v=spf1 include:_spf.mlsend.com ip4:194.33.196.8/32 ip4:194.33.192.8/32 include:spf.protection.outlook.com
       -all
+    - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
 _90a26ed25d4dc817fe7ddb874d5fc26c.mta-sts:
   ttl: 60
   type: CNAME

--- a/hostedzones/ima-citizensrights.org.uk.yaml
+++ b/hostedzones/ima-citizensrights.org.uk.yaml
@@ -25,6 +25,7 @@
     - google-site-verification=ZF9wtpT_YiWaUp4t18aOheIRck4ZM6F4ejm80HGAsmc
     - v=spf1 mx ip4:194.33.196.0/24 ip4:194.33.192.0/24 include:spf.protection.outlook.com
       include:_spf.google.com include:spf.mandrillapp.com -all
+    - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
 _6a19d3849cc84ad68c492edf9ce06d44:
   ttl: 300
   type: CNAME

--- a/hostedzones/judicialappointments.gov.uk.yaml
+++ b/hostedzones/judicialappointments.gov.uk.yaml
@@ -26,6 +26,7 @@
     - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
     - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32  include:spf.protection.outlook.com
       -all
+    - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
 _6351f8e182881f77d161743e5cf255f9.mta-sts:
   ttl: 60
   type: CNAME

--- a/hostedzones/judicialconduct.gov.uk.yaml
+++ b/hostedzones/judicialconduct.gov.uk.yaml
@@ -17,6 +17,7 @@
     - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
     - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32  include:spf.protection.outlook.com
       -all
+    - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
 _0be96fa6a7f31b10a5bde19c35df1966.mta-sts:
   ttl: 60
   type: CNAME

--- a/hostedzones/judicialombudsman.gov.uk.yaml
+++ b/hostedzones/judicialombudsman.gov.uk.yaml
@@ -24,6 +24,7 @@
     - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
     - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32  include:spf.protection.outlook.com
       -all
+    - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
 _asvdns-f18eb53a-95d7-4b71-935e-359501e3ca99:
   ttl: 300
   type: TXT

--- a/hostedzones/judiciary.uk.yaml
+++ b/hostedzones/judiciary.uk.yaml
@@ -24,6 +24,7 @@
     - ujatii6o116ahi7u28r22h982t
     - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32 ip4:78.31.108.141 include:spf.protection.outlook.com
       include:ciphr247.com -all
+    - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
 5vl4vla56j76p3obneqqnjelrynl2kiv._domainkey.elinks-staging-email.elinks:
   type: CNAME
   value: 5vl4vla56j76p3obneqqnjelrynl2kiv.dkim.amazonses.com

--- a/hostedzones/lawcommission.gov.uk.yaml
+++ b/hostedzones/lawcommission.gov.uk.yaml
@@ -17,6 +17,7 @@
     - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
     - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32  include:spf.protection.outlook.com
       -all
+    - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
 _asvdns-7f96cfbc-c539-4350-9631-a61dfcdba928:
   ttl: 300
   type: TXT

--- a/hostedzones/ospt.gov.uk.yaml
+++ b/hostedzones/ospt.gov.uk.yaml
@@ -24,6 +24,7 @@
     - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
     - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32  include:spf.protection.outlook.com
       -all
+    - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
 47klhk64a2fmag4rljvb7umybpa22yff._domainkey:
   ttl: 300
   type: CNAME

--- a/hostedzones/publicguardian.gov.uk.yaml
+++ b/hostedzones/publicguardian.gov.uk.yaml
@@ -26,6 +26,7 @@
     - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
     - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32 include:spf.protection.outlook.com
       -all
+    - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
 _asvdns-8a5e9946-76d7-4e78-83b0-5f3be2e0e7b0:
   ttl: 300
   type: TXT

--- a/hostedzones/sentencingcouncil.gov.uk.yaml
+++ b/hostedzones/sentencingcouncil.gov.uk.yaml
@@ -17,6 +17,7 @@
     - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
     - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32  include:spf.protection.outlook.com
       -all
+    - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
 _00820e901725762056fdc35127f0004e.mta-sts:
   ttl: 60
   type: CNAME

--- a/hostedzones/yjb.gov.uk.yaml
+++ b/hostedzones/yjb.gov.uk.yaml
@@ -25,6 +25,7 @@
     - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
     - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32 ip4:5.61.115.16/28  include:spf.protection.outlook.com
       -all
+    - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
 2dbx4addpy7nyj76mioylqhzphrymyma._domainkey:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR adds Miro and Atlassian validation records for email related domains. This is to ensure that users with email domains other than `justice.gov.uk` or `digital.justice.gov.uk` can use SSO to access Miro, Jira and Confluence.

## ♻️ What's changed

- Updates `@domain` TXT records with `miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab` and `atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby` to the email domains

## 📝 Notes

- Requested by Service Desk