### PR TITLE
Add ACM validation CNAMES

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -51,6 +51,10 @@ _59E0EA73F42CCD9BAC5B7D141F162C59.hmpps-canine-management:
   ttl: 300
   type: CNAME
   value: 934074720C4E69907DA00101D5B4100D.D3B5DE6EDC9E127AF700C06913D46BDA.6fbc40a7097384fd9d1b.sectigo.com.
+_8f2a1999a9e110af3685208ee3875799.preprod.manage-external-funded-offender-provision:
+  ttl: 300
+  type: CNAME
+  value: _319d4c72bdfe59b5b6d40f8409b78e65.sdgjtdhdhz.acm-validations.aws.
 _95ea75a7f508104bbae8244e26130e7e.advance-into-justice:
   ttl: 300
   type: CNAME
@@ -111,6 +115,10 @@ _cd274e7ee824297d08388d398a2b2b8a.crown-court-remuneration:
   ttl: 300
   type: CNAME
   value: _b2d6197bf0aa1d024b5fef68a13127bb.fpwkmzyskh.acm-validations.aws.
+_cdead2a6631b56289db2e235ff1b0686.preprod.creatingfutureopportunities:
+  ttl: 300
+  type: CNAME
+  value: _651516d4aff63b910272df3cfa5af0dc.sdgjtdhdhz.acm-validations.aws.
 _d8e015eb77621a22d1bb4fe339ec1ebd.dev.manage-external-funded-offender-provision:
   ttl: 300
   type: CNAME

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -43,6 +43,10 @@ _6f2592c897ce1cb57321ce86823bba01.www.find-unclaimed-court-money:
   ttl: 300
   type: CNAME
   value: _b889b9713a37c39694f437333e017428.chvvfdvqrj.acm-validations.aws.
+_8f2a1999a9e110af3685208ee3875799.preprod.manage-external-funded-offender-provision:
+  ttl: 300
+  type: CNAME
+  value: _319d4c72bdfe59b5b6d40f8409b78e65.sdgjtdhdhz.acm-validations.aws.
 _33da21e90254237bcc4d8ad00bd3d118.security-training:
   ttl: 300
   type: CNAME
@@ -51,10 +55,6 @@ _59E0EA73F42CCD9BAC5B7D141F162C59.hmpps-canine-management:
   ttl: 300
   type: CNAME
   value: 934074720C4E69907DA00101D5B4100D.D3B5DE6EDC9E127AF700C06913D46BDA.6fbc40a7097384fd9d1b.sectigo.com.
-_8f2a1999a9e110af3685208ee3875799.preprod.manage-external-funded-offender-provision:
-  ttl: 300
-  type: CNAME
-  value: _319d4c72bdfe59b5b6d40f8409b78e65.sdgjtdhdhz.acm-validations.aws.
 _95ea75a7f508104bbae8244e26130e7e.advance-into-justice:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR adds two CNAMES for ACM SSL certificate validation.

## ♻️ What's changed

- adds CNAME `_cdead2a6631b56289db2e235ff1b0686.preprod.creatingfutureopportunities.service.justice.gov.uk`
- adds CNAME `_8f2a1999a9e110af3685208ee3875799.preprod.manage-external-funded-offender-provision.service.justice.gov.uk`