### PR TITLE
Remove dangling DNS record

### DIFF
--- a/hostedzones/judiciary.gov.uk.yaml
+++ b/hostedzones/judiciary.gov.uk.yaml
@@ -118,10 +118,6 @@ search:
   ttl: 600
   type: A
   value: 212.44.22.84
-search.sentencingcouncil:
-  ttl: 600
-  type: CNAME
-  value: search2.openobjects.com.
 sec:
   ttl: 600
   type: A


### PR DESCRIPTION
## 👀 Purpose

- This PR removes dangling DNS records reported by CDDO to domains@digital.justice.gov.uk on 2nd July 2024.

## ♻️ What's changed

Removes the following CNAMES from `judiciary.gov.uk` hostedzone:
- `search.sentencingcouncil.judiciary.gov.uk`
