### PR TITLE
🔥 Remove Legacy Skype Records in `publicgaurdian.gov.uk`

### DIFF
--- a/hostedzones/publicguardian.gov.uk.yaml
+++ b/hostedzones/publicguardian.gov.uk.yaml
@@ -1,5 +1,5 @@
 ---
-'':
+"":
   - ttl: 300
     type: MX
     value:
@@ -51,14 +51,6 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=819c02822a127057b73187264f0816e3
-_sip._tls:
-  ttl: 300
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com
-    weight: 1
 _sipfederationtls._tcp:
   ttl: 300
   type: SRV
@@ -87,10 +79,6 @@ fp01._domainkey:
   ttl: 300
   type: TXT
   value: v=DKIM1\; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCN/Dnp6gO1PJVQgLljNpkkvVUH/G04C2QkC28j8ddX13V7MAvDWpCxnUfTPy8C27njUImSa8b2TwyeA0P2ONPHQhW652tSxZa0+VT2b5qRFhne3UigZEeKhix988mhlOTO+6PN4+JR7MPXSeE0iGGPWm8m4JsxeaVvwN0XC92yvQIDAQAB\;
-lyncdiscover:
-  ttl: 300
-  type: CNAME
-  value: webdir.online.lync.com
 mirovalidation:
   ttl: 300
   type: TXT
@@ -115,10 +103,6 @@ selector2._domainkey:
   ttl: 300
   type: CNAME
   value: selector2-publicguardian-gov-uk._domainkey.justiceuk.onmicrosoft.com
-sip:
-  ttl: 300
-  type: CNAME
-  value: sipdir.online.lync.com
 sirius:
   ttl: 300
   type: NS


### PR DESCRIPTION
## 👀 Purpose

- To remove legacy records relating to the now deprecated Skype For Business Online

## ♻️ What's changed

- Removed SRV record _sip._tls.publicgaurdian.gov.uk
- Removed CNAME record sip.publicgaurdian.gov.uk
- Removed CNAME record lyncdiscover.publicgaurdian.gov.uk 

## 📝 Notes

- Deleted records are the ones required to [set up Skype for Business](https://learn.microsoft.com/en-us/microsoft-365/admin/dns/create-dns-records-at-aws?view=o365-worldwide#advanced-option-skype-for-business)
- The remaining record is the only record (`_sipfederationtls._tcp`) is [required for Teams](https://learn.microsoft.com/en-us/skypeforbusiness/hybrid/decommission-manage-dns-entries#dns-records-to-be-updated)
- [Domain is hosted in an M365 Tennant configured for TeamsOnly](https://mojdt.slack.com/archives/C0282GUGKL7/p1722326053493419?thread_ts=1722246363.663929&cid=C0282GUGKL7) - so Skype can no longer be used, meaning this change should result in no impact to any current services