### PR TITLE
DRAFT: Mail DNS Changes for dutysolicitors.org

### DIFF
--- a/hostedzones/dutysolicitors.org.yaml
+++ b/hostedzones/dutysolicitors.org.yaml
@@ -15,7 +15,7 @@
       - ns-197.awsdns-24.com.
       - ns-553.awsdns-05.net.
   - type: TXT
-    values: [MS=ms36435977, v=spf1 include:spf.protection.outlook.com -all]
+    values: [MS=ms36435977, v=spf1 include:spf.protection.outlook.com include:eu.rp.oracleemaildelivery.com -all]
 _05C2A69FE55101F895523696988C2752:
   ttl: 300
   type: CNAME

--- a/hostedzones/dutysolicitors.org.yaml
+++ b/hostedzones/dutysolicitors.org.yaml
@@ -32,6 +32,10 @@ _dmarc:
   ttl: 300
   type: TXT
   value: v=DMARC1\;p=none\;sp=none\;rua=mailto:dmarc-rua@dmarc.service.gov.uk
+dutysolicitors-lhr-202407._domainkey.dutysolicitors.org:
+  ttl: 300
+  type: TXT
+  value: v=DKIM1;h=sha256;p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmg8eNURpOzOL39wyYts6kP8rgES4FoYw1IZ64uT03m5jzi0oxo8qxJ8yOXUIjlWow+/T6AXW9NfvMCOlkV80V8P4WUf/46Brw3JSm3OCFaE0nXLe/i6P2TWG94fcDwirW3D7+k8Ioxeyk+Fu1AL2UXhY0CS6h1Hn6HS2CZNZXB4HsfnxAEoOnKVAdcUwxMgAD+AqQUT9Am9ztLeJ/90gk71C8fydrV3O390691VXLPDopu1UbvWnzJchnA0OMOTFomNR+DUIHFJKOh+uxj4t8d/0lWG5IxtmKyN9jUnADh82EbG3UfwZsbhNNqfi5QS3VGaWHfZQLb0dm+DHtBqSQQIDAQAB
 _smtp._tls:
   ttl: 300
   type: TXT


### PR DESCRIPTION
## 👀 Purpose

There is currently work going on to migrate the LAA application infrastructure from Milton Keynes on premise to Govt Cage OC4 in Oracle's OCI. As part of this migration, some DNS changes are required for mail authentication.

## ♻️ What's Changed

- [New TXT record added for DKIM authentication](https://github.com/ministryofjustice/dns/commit/6bca9c1869c41865b01dcbbf4d264170958bbc6c)
- [Record value updated to Oracle SMTP addresses](https://github.com/ministryofjustice/dns/commit/9bacb3903240019cd4c2def706bbb73fa583863b)

## 📝 Notes

No notes to speak of.