### PR TITLE
:sparkles: Added routing for URL to old CloudFront Instance

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -922,6 +922,10 @@ lawcommission.intranet:
   ttl: 300
   type: CNAME
   value: lawcomintranet.prod.wp.dsd.io
+legacy.manage-external-funded-offender-provision:
+  ttl: 300
+  type: CNAME
+  value: d2p66dhqonjkjj.cloudfront.net
 legalaidagency.intranet:
   ttl: 300
   type: A


### PR DESCRIPTION
## 👀 Purpose

To route `legacy.manage-external-funded-offender-provision` to old CloudFront address now the migration has taken place.

## ♻️ What's Changed

- Added CNAME record for `legacy.manage-external-funded-offender-provision`

## 📝 Notes

No notes to speak of.