### PR TITLE
Add GitHub domain ownership validation for `data-catalogue` subdomains

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -175,6 +175,10 @@ _gh-ministryofjustice-o.runbooks.data-catalogue:
   ttl: 300
   type: TXT
   value: e3280b1fd3
+_gh-ministryofjustice-o.user-guide.data-catalogue:
+  ttl: 300
+  type: TXT
+  value: 9d4224abcb
 _github-challenge-ministryof-org.operations-engineering:
   ttl: 300
   type: TXT

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -171,6 +171,10 @@ _gh-ministryofjustice-o.ministry-of-justice-acronyms:
   ttl: 300
   type: TXT
   value: 0abfb08cbf
+_gh-ministryofjustice-o.runbooks.data-catalogue:
+  ttl: 300
+  type: TXT
+  value: e3280b1fd3
 _github-challenge-ministryof-org.operations-engineering:
   ttl: 300
   type: TXT


### PR DESCRIPTION
## 👀 Purpose

- The PR adds GitHub domain ownership validation records to avoid deleted gh pages site domains being open to takeover. These TXT records ensure that domains remain in our ownership even if not is use.

## ♻️ What's changed

- Adds TXT record `_gh-ministryofjustice-o.runbooks.data-catalogue.service.justice.gov.uk`
- Adds TXT record `_gh-ministryofjustice-o.user-guide.data-catalogue.service.justice.gov.uk`

## 📝 Notes

- [Related thread](https://mojdt.slack.com/archives/C01BUKJSZD4/p1723031935741849)