### PR TITLE
Add ACM validation CNAMES

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -25,6 +25,10 @@
   - ttl: 300
     type: TXT
     values: [MS=ms96686635, v=spf1 ~all]
+_047fab8b93aa6da0699b1cc4413bd685.crown-court-litigator-fees:
+  ttl: 300
+  type: CNAME
+  value: _3adaedf9b6a02203fa8fa05d5e4df6e1.sdgjtdhdhz.acm-validations.aws.
 _0c5ef000e3292b5574d86de97bdd9bbb.pp.exchange-integration-services-stream:
   ttl: 300
   type: CNAME
@@ -163,6 +167,10 @@ _e8920487ae3f822284e61ac444e7c639.legacy.creatingfutureopportunities:
   ttl: 300
   type: CNAME
   value: _d09d7b96049f80c055e97e0e2bcba5fe.sdgjtdhdhz.acm-validations.aws.
+_ecfb89dfe84df8c70d927c0cad621a50.crown-court-remuneration:
+  ttl: 300
+  type: CNAME
+  value: _b60e6afbf5f45a5d468ec5b937aaa428.sdgjtdhdhz.acm-validations.aws.
 _f1d407a6cf4f3710e0f45c21cfc6558a.hmctsknowledgemanagement:
   ttl: 300
   type: CNAME

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -49,6 +49,10 @@ _33da21e90254237bcc4d8ad00bd3d118.security-training:
   ttl: 300
   type: CNAME
   value: _6165ac1a2a05feaefa1cc4aaf7d09b0b.kgnrpmcdhl.acm-validations.aws.
+_047fab8b93aa6da0699b1cc4413bd685.crown-court-litigator-fees:
+  ttl: 300
+  type: CNAME
+  value: _3adaedf9b6a02203fa8fa05d5e4df6e1.sdgjtdhdhz.acm-validations.aws.
 _59E0EA73F42CCD9BAC5B7D141F162C59.hmpps-canine-management:
   ttl: 300
   type: CNAME
@@ -77,10 +81,6 @@ _39556719e8d565ea45417d38b40889c7.find-unclaimed-court-money:
   ttl: 60
   type: CNAME
   value: _06c52dec40633865541b0ff381d9eeb1.chvvfdvqrj.acm-validations.aws
-_047fab8b93aa6da0699b1cc4413bd685.crown-court-litigator-fees:
-  ttl: 300
-  type: CNAME
-  value: _3adaedf9b6a02203fa8fa05d5e4df6e1.sdgjtdhdhz.acm-validations.aws.
 _a8acf57184d83c241b9b8595c4cb0bd0.crown-court-litigator-fees:
   ttl: 300
   type: CNAME

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -25,10 +25,6 @@
   - ttl: 300
     type: TXT
     values: [MS=ms96686635, v=spf1 ~all]
-_047fab8b93aa6da0699b1cc4413bd685.crown-court-litigator-fees:
-  ttl: 300
-  type: CNAME
-  value: _3adaedf9b6a02203fa8fa05d5e4df6e1.sdgjtdhdhz.acm-validations.aws.
 _0c5ef000e3292b5574d86de97bdd9bbb.pp.exchange-integration-services-stream:
   ttl: 300
   type: CNAME
@@ -41,6 +37,10 @@ _0cbf0f810ad5c633d700bb504ca45b1f.intranet:
   ttl: 300
   type: CNAME
   value: _d54a4c592ad02000b032201b8e535d4b.btsqtkxpyp.acm-validations.aws.
+_047fab8b93aa6da0699b1cc4413bd685.crown-court-litigator-fees:
+  ttl: 300
+  type: CNAME
+  value: _3adaedf9b6a02203fa8fa05d5e4df6e1.sdgjtdhdhz.acm-validations.aws.
 _6f2592c897ce1cb57321ce86823bba01.www.find-unclaimed-court-money:
   ttl: 300
   type: CNAME

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -37,10 +37,6 @@ _0cbf0f810ad5c633d700bb504ca45b1f.intranet:
   ttl: 300
   type: CNAME
   value: _d54a4c592ad02000b032201b8e535d4b.btsqtkxpyp.acm-validations.aws.
-_047fab8b93aa6da0699b1cc4413bd685.crown-court-litigator-fees:
-  ttl: 300
-  type: CNAME
-  value: _3adaedf9b6a02203fa8fa05d5e4df6e1.sdgjtdhdhz.acm-validations.aws.
 _6f2592c897ce1cb57321ce86823bba01.www.find-unclaimed-court-money:
   ttl: 300
   type: CNAME
@@ -81,6 +77,10 @@ _39556719e8d565ea45417d38b40889c7.find-unclaimed-court-money:
   ttl: 60
   type: CNAME
   value: _06c52dec40633865541b0ff381d9eeb1.chvvfdvqrj.acm-validations.aws
+_047fab8b93aa6da0699b1cc4413bd685.crown-court-litigator-fees:
+  ttl: 300
+  type: CNAME
+  value: _3adaedf9b6a02203fa8fa05d5e4df6e1.sdgjtdhdhz.acm-validations.aws.
 _a8acf57184d83c241b9b8595c4cb0bd0.crown-court-litigator-fees:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR add a number of AWS ACM validation CNAMES for new certificates

## ♻️ What's changed

- Add CNAME `_047fab8b93aa6da0699b1cc4413bd685.crown-court-litigator-fees.service.justice.gov.uk`
- Add CNAME `_ecfb89dfe84df8c70d927c0cad621a50.crown-court-remuneration.service.justice.gov.uk`