### PR TITLE
Add Gandi.net cert validation CNAMES

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -202,6 +202,14 @@ _domainkey.people-development:
   ttl: 300
   type: TXT
   value: t=y\; o=~\;
+_E0FCB7A4ABED1635BDA3D6DB5D95F573.courtstore:
+  ttl: 300
+  type: CNAME
+  value: F862680DD81DCEEDCB1A191579BED387.EF5F69DF8020D304280D692B9C9D8AE8.434c5bd6ebcf5a3c8e71.sectigo.com.
+_EFF93CC62AEBD03595E86398C5A5DF88.staff.court.store:
+  ttl: 300
+  type: CNAME
+  value: 22FBA9D12FC54A2DB5CC8A1FBDAF3401.9459C11735B5E5436E55CF5B00FFE8EF.b61b26dc97a3b3975cdc.sectigo.com.
 _github-challenge-hmcts:
   ttl: 300
   type: TXT

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -71,6 +71,10 @@ _E0FCB7A4ABED1635BDA3D6DB5D95F573.courtstore:
   ttl: 300
   type: CNAME
   value: F862680DD81DCEEDCB1A191579BED387.EF5F69DF8020D304280D692B9C9D8AE8.434c5bd6ebcf5a3c8e71.sectigo.com.
+_EFF93CC62AEBD03595E86398C5A5DF88.staff.court.store:
+  ttl: 300
+  type: CNAME
+  value: 22FBA9D12FC54A2DB5CC8A1FBDAF3401.9459C11735B5E5436E55CF5B00FFE8EF.b61b26dc97a3b3975cdc.sectigo.com.
 _acme-challenge.aka:
   ttl: 300
   type: CNAME
@@ -206,10 +210,6 @@ _domainkey.people-development:
   ttl: 300
   type: TXT
   value: t=y\; o=~\;
-_EFF93CC62AEBD03595E86398C5A5DF88.staff.court.store:
-  ttl: 300
-  type: CNAME
-  value: 22FBA9D12FC54A2DB5CC8A1FBDAF3401.9459C11735B5E5436E55CF5B00FFE8EF.b61b26dc97a3b3975cdc.sectigo.com.
 _github-challenge-hmcts:
   ttl: 300
   type: TXT

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -67,6 +67,10 @@ _413907afca971cfa53aab8d5df86e4ef.bench.courtstore:
   ttl: 300
   type: CNAME
   value: 99676425dda31d813e393d4d1551f41c.2a3726c1103d2824e6ffcce77ad998ad.1298432b58b57b0ca19f.sectigo.com.
+_E0FCB7A4ABED1635BDA3D6DB5D95F573.courtstore:
+  ttl: 300
+  type: CNAME
+  value: F862680DD81DCEEDCB1A191579BED387.EF5F69DF8020D304280D692B9C9D8AE8.434c5bd6ebcf5a3c8e71.sectigo.com.
 _acme-challenge.aka:
   ttl: 300
   type: CNAME
@@ -202,10 +206,6 @@ _domainkey.people-development:
   ttl: 300
   type: TXT
   value: t=y\; o=~\;
-_E0FCB7A4ABED1635BDA3D6DB5D95F573.courtstore:
-  ttl: 300
-  type: CNAME
-  value: F862680DD81DCEEDCB1A191579BED387.EF5F69DF8020D304280D692B9C9D8AE8.434c5bd6ebcf5a3c8e71.sectigo.com.
 _EFF93CC62AEBD03595E86398C5A5DF88.staff.court.store:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- PR adds Gandi.net cert validation CNAMES

## ♻️ What's changed

- adds CNAME `_E0FCB7A4ABED1635BDA3D6DB5D95F573.courtstore.justice.gov.uk`
- adds CNAME `_EFF93CC62AEBD03595E86398C5A5DF88.staff.court.store.justice.gov.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/certificates/c/uMczgX9FCwM/m/Z5CGipcGBwAJ)