### PR TITLE
Add ACM validation CNAMES

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -65,6 +65,10 @@ _95ea75a7f508104bbae8244e26130e7e.advance-into-justice:
   ttl: 300
   type: CNAME
   value: _7bd56adf412cd4bc93a83eeb6d808f81.ylqxxscwpq.acm-validations.aws
+_122d4a537f580579f8a5aa1308c76d7a.crown-court-litigator-fees:
+  ttl: 300
+  type: CNAME
+  value: _22de9d65d0c7985f9b55997aedbbf7d1.sdgjtdhdhz.acm-validations.aws.
 _935f4ad292e31cb21e5bf6043b20a2bf.securecodewarrior:
   ttl: 300
   type: CNAME
@@ -77,10 +81,6 @@ _38914c2fe17df3d640a7d1d9765d8c88.training-preproduction.co-financing:
   ttl: 300
   type: CNAME
   value: _52106b9eec58031689a9b3d42d21d129.mqzgcdqkwq.acm-validations.aws.
-_122d4a537f580579f8a5aa1308c76d7a.crown-court-litigator-fees:
-  ttl: 300
-  type: CNAME
-  value: _22de9d65d0c7985f9b55997aedbbf7d1.sdgjtdhdhz.acm-validations.aws.
 _1864366b68aacd731e332b25536285ec.youth-justice-worker-online-assessment:
   ttl: 300
   type: CNAME

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -57,10 +57,6 @@ _047fab8b93aa6da0699b1cc4413bd685.crown-court-litigator-fees:
   ttl: 300
   type: CNAME
   value: _3adaedf9b6a02203fa8fa05d5e4df6e1.sdgjtdhdhz.acm-validations.aws.
-_122d4a537f580579f8a5aa1308c76d7a.crown-court-litigator-fees:
-  ttl: 300
-  type: CNAME
-  value: _22de9d65d0c7985f9b55997aedbbf7d1.sdgjtdhdhz.acm-validations.aws.
 _59E0EA73F42CCD9BAC5B7D141F162C59.hmpps-canine-management:
   ttl: 300
   type: CNAME
@@ -81,6 +77,10 @@ _38914c2fe17df3d640a7d1d9765d8c88.training-preproduction.co-financing:
   ttl: 300
   type: CNAME
   value: _52106b9eec58031689a9b3d42d21d129.mqzgcdqkwq.acm-validations.aws.
+_122d4a537f580579f8a5aa1308c76d7a.crown-court-litigator-fees:
+  ttl: 300
+  type: CNAME
+  value: _22de9d65d0c7985f9b55997aedbbf7d1.sdgjtdhdhz.acm-validations.aws.
 _1864366b68aacd731e332b25536285ec.youth-justice-worker-online-assessment:
   ttl: 300
   type: CNAME

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -45,6 +45,10 @@ _8f2a1999a9e110af3685208ee3875799.preprod.manage-external-funded-offender-provis
   ttl: 300
   type: CNAME
   value: _319d4c72bdfe59b5b6d40f8409b78e65.sdgjtdhdhz.acm-validations.aws.
+_23efb19098b76b45fd95c83d92a224dc.crown-court-remuneration:
+  ttl: 300
+  type: CNAME
+  value: _6ada085e17b809adf7fa1bc34003d010.sdgjtdhdhz.acm-validations.aws.
 _33da21e90254237bcc4d8ad00bd3d118.security-training:
   ttl: 300
   type: CNAME
@@ -57,10 +61,6 @@ _122d4a537f580579f8a5aa1308c76d7a.crown-court-litigator-fees:
   ttl: 300
   type: CNAME
   value: _22de9d65d0c7985f9b55997aedbbf7d1.sdgjtdhdhz.acm-validations.aws.
-_23efb19098b76b45fd95c83d92a224dc.crown-court-remuneration:
-  ttl: 300
-  type: CNAME
-  value: _6ada085e17b809adf7fa1bc34003d010.sdgjtdhdhz.acm-validations.aws.
 _59E0EA73F42CCD9BAC5B7D141F162C59.hmpps-canine-management:
   ttl: 300
   type: CNAME

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -37,14 +37,6 @@ _0cbf0f810ad5c633d700bb504ca45b1f.intranet:
   ttl: 300
   type: CNAME
   value: _d54a4c592ad02000b032201b8e535d4b.btsqtkxpyp.acm-validations.aws.
-_122d4a537f580579f8a5aa1308c76d7a.crown-court-litigator-fees:
-  ttl: 300
-  type: CNAME
-  value: _22de9d65d0c7985f9b55997aedbbf7d1.sdgjtdhdhz.acm-validations.aws.
-_23efb19098b76b45fd95c83d92a224dc.crown-court-remuneration:
-  ttl: 300
-  type: CNAME
-  value: _6ada085e17b809adf7fa1bc34003d010.sdgjtdhdhz.acm-validations.aws.
 _6f2592c897ce1cb57321ce86823bba01.www.find-unclaimed-court-money:
   ttl: 300
   type: CNAME
@@ -61,6 +53,14 @@ _047fab8b93aa6da0699b1cc4413bd685.crown-court-litigator-fees:
   ttl: 300
   type: CNAME
   value: _3adaedf9b6a02203fa8fa05d5e4df6e1.sdgjtdhdhz.acm-validations.aws.
+_122d4a537f580579f8a5aa1308c76d7a.crown-court-litigator-fees:
+  ttl: 300
+  type: CNAME
+  value: _22de9d65d0c7985f9b55997aedbbf7d1.sdgjtdhdhz.acm-validations.aws.
+_23efb19098b76b45fd95c83d92a224dc.crown-court-remuneration:
+  ttl: 300
+  type: CNAME
+  value: _6ada085e17b809adf7fa1bc34003d010.sdgjtdhdhz.acm-validations.aws.
 _59E0EA73F42CCD9BAC5B7D141F162C59.hmpps-canine-management:
   ttl: 300
   type: CNAME

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -37,6 +37,14 @@ _0cbf0f810ad5c633d700bb504ca45b1f.intranet:
   ttl: 300
   type: CNAME
   value: _d54a4c592ad02000b032201b8e535d4b.btsqtkxpyp.acm-validations.aws.
+_122d4a537f580579f8a5aa1308c76d7a.crown-court-litigator-fees:
+  ttl: 300
+  type: CNAME
+  value: _22de9d65d0c7985f9b55997aedbbf7d1.sdgjtdhdhz.acm-validations.aws.
+_23efb19098b76b45fd95c83d92a224dc.crown-court-remuneration:
+  ttl: 300
+  type: CNAME
+  value: _6ada085e17b809adf7fa1bc34003d010.sdgjtdhdhz.acm-validations.aws.
 _6f2592c897ce1cb57321ce86823bba01.www.find-unclaimed-court-money:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR add a number of AWS ACM validation CNAMES for new certificates

## ♻️ What's changed

- Add CNAME `_122d4a537f580579f8a5aa1308c76d7a.crown-court-litigator-fees.service.justice.gov.uk`
- Add CNAME `_23efb19098b76b45fd95c83d92a224dc.crown-court-remuneration.service.justice.gov.uk`