### PR TITLE
Remove old cert validation CNAMES

### DIFF
--- a/hostedzones/video.service.justice.gov.uk.yaml
+++ b/hostedzones/video.service.justice.gov.uk.yaml
@@ -39,38 +39,6 @@ _BBFDAC5266B413B0F868E14FDD7FDA21.www.playback:
   ttl: 300
   type: CNAME
   value: 59F213B4B0EE0630D1750E22039228A9.1E7EA8320EC9E2E95D59D38F08978B32.77068b6b1dc411f016b9.sectigo.com.
-_ad6f5bac936f7983cdac02c521925772.playback:
-  ttl: 300
-  type: CNAME
-  value: f21718b83ce0aaed10d97b6512a29853.9cebaae94700ab2953eb0390d18b8cdd.9ab71d7cd706e7b5ae6f.sectigo.com.
-_ad6f5bac936f7983cdac02c521925772.playback1:
-  ttl: 300
-  type: CNAME
-  value: f21718b83ce0aaed10d97b6512a29853.9cebaae94700ab2953eb0390d18b8cdd.9ab71d7cd706e7b5ae6f.sectigo.com.
-_ad6f5bac936f7983cdac02c521925772.playback2:
-  ttl: 300
-  type: CNAME
-  value: f21718b83ce0aaed10d97b6512a29853.9cebaae94700ab2953eb0390d18b8cdd.9ab71d7cd706e7b5ae6f.sectigo.com.
-_ad6f5bac936f7983cdac02c521925772.playback3:
-  ttl: 300
-  type: CNAME
-  value: f21718b83ce0aaed10d97b6512a29853.9cebaae94700ab2953eb0390d18b8cdd.9ab71d7cd706e7b5ae6f.sectigo.com.
-_ad6f5bac936f7983cdac02c521925772.playback4:
-  ttl: 300
-  type: CNAME
-  value: f21718b83ce0aaed10d97b6512a29853.9cebaae94700ab2953eb0390d18b8cdd.9ab71d7cd706e7b5ae6f.sectigo.com.
-_ad6f5bac936f7983cdac02c521925772.playback5:
-  ttl: 300
-  type: CNAME
-  value: f21718b83ce0aaed10d97b6512a29853.9cebaae94700ab2953eb0390d18b8cdd.9ab71d7cd706e7b5ae6f.sectigo.com.
-_ad6f5bac936f7983cdac02c521925772.playback6:
-  ttl: 300
-  type: CNAME
-  value: f21718b83ce0aaed10d97b6512a29853.9cebaae94700ab2953eb0390d18b8cdd.9ab71d7cd706e7b5ae6f.sectigo.com.
-_ad6f5bac936f7983cdac02c521925772.www.playback:
-  ttl: 300
-  type: CNAME
-  value: f21718b83ce0aaed10d97b6512a29853.9cebaae94700ab2953eb0390d18b8cdd.9ab71d7cd706e7b5ae6f.sectigo.com.
 playback:
   ttl: 60
   type: A


### PR DESCRIPTION
## 👀 Purpose

- The PR cleans-up the old gandi.net CNAME records used for the previous certificate renewal. These are no longer required. Keeps the zone nice and tidy.

## ♻️ What's changed

- Removes 8 old CNAME records