### PR TITLE
Remove dangling SIP records

### DIFF
--- a/hostedzones/devl.justice.gov.uk.yaml
+++ b/hostedzones/devl.justice.gov.uk.yaml
@@ -21,13 +21,6 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=4adfca9f114c6d7c82119b69fa97fece
-_sip._tls:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com.
-    weight: 1
 _sipfederationtls._tcp:
   type: SRV
   value:
@@ -59,6 +52,3 @@ mta-sts:
     hosted-zone-id: Z2FDTNDATAQYW2
     name: d1k9a5875p40im.cloudfront.net.
     type: A
-sip:
-  type: CNAME
-  value: sipdir.online.lync.com

--- a/hostedzones/digital.justice.gov.uk.yaml
+++ b/hostedzones/digital.justice.gov.uk.yaml
@@ -83,14 +83,6 @@ _pop3s._tcp:
     priority: 10
     target: pop.gmail.com.
     weight: 0
-_sip._tls.test:
-  ttl: 300
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com
-    weight: 1
 _sipfederationtls.tcp.test:
   ttl: 300
   type: SRV
@@ -284,10 +276,6 @@ sfpp.mobile:
   ttl: 300
   type: A
   value: 157.203.177.166
-sip.test:
-  ttl: 300
-  type: CNAME
-  value: sipdir.online.lync.com.
 sso:
   ttl: 300
   type: CNAME

--- a/hostedzones/govfsl.com.yaml
+++ b/hostedzones/govfsl.com.yaml
@@ -40,13 +40,6 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=14e8765cc6063cdb4e6f4b744f975d43
-_sip._tls:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com
-    weight: 1
 _sipfederationtls._tcp:
   type: SRV
   value:
@@ -94,9 +87,6 @@ selector2._domainkey:
   ttl: 300
   type: CNAME
   value: selector2-govfsl-com._domainkey.justiceuk.onmicrosoft.com
-sip:
-  type: CNAME
-  value: sipdir.online.lync.com
 smartsheet-site-validation:
   ttl: 300
   type: TXT

--- a/hostedzones/hmiprisons.gov.uk.yaml
+++ b/hostedzones/hmiprisons.gov.uk.yaml
@@ -35,13 +35,6 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=a9e2b55dbbb2b9e38e8ccf6b9a194dd8
-_sip._tls:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com
-    weight: 1
 _sipfederationtls._tcp:
   type: SRV
   value:
@@ -89,6 +82,3 @@ selector1._domainkey:
 selector2._domainkey:
   type: CNAME
   value: selector2-hmiprisons-gov-uk._domainkey.justiceuk.onmicrosoft.com
-sip:
-  type: CNAME
-  value: sipdir.online.lync.com

--- a/hostedzones/hmiprobation.gov.uk.yaml
+++ b/hostedzones/hmiprobation.gov.uk.yaml
@@ -35,13 +35,6 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=a1f3eda4db6d3e19a92f6cb5879a4298
-_sip._tls:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com
-    weight: 1
 _sipfederationtls._tcp:
   type: SRV
   value:
@@ -90,6 +83,3 @@ selector1._domainkey:
 selector2._domainkey:
   type: CNAME
   value: selector2-hmiprobation-gov-uk._domainkey.justiceuk.onmicrosoft.com
-sip:
-  type: CNAME
-  value: sipdir.online.lync.com

--- a/hostedzones/ima-citizensrights.org.uk.yaml
+++ b/hostedzones/ima-citizensrights.org.uk.yaml
@@ -80,13 +80,6 @@ _mta-sts.newsletter:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=d65d64c87f52fedec05bca206b6630df
-_sip._tls:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com
-    weight: 1
 _sipfederationtls._tcp:
   type: SRV
   value:
@@ -208,9 +201,6 @@ selector2._domainkey:
   ttl: 300
   type: CNAME
   value: selector2-imacitizensrights-org-uk0i._domainkey.justiceuk.onmicrosoft.com
-sip:
-  type: CNAME
-  value: sipdir.online.lync.com
 survey:
   ttl: 600
   type: CNAME

--- a/hostedzones/judicialappointments.gov.uk.yaml
+++ b/hostedzones/judicialappointments.gov.uk.yaml
@@ -45,13 +45,6 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=c7d26af1a5ba18e6d7e8dcfb2e1f67ef
-_sip._tls:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com
-    weight: 1
 _sipfederationtls._tcp:
   type: SRV
   value:
@@ -105,9 +98,6 @@ selector1._domainkey:
 selector2._domainkey:
   type: CNAME
   value: selector2-judicialappointments-gov-uk._domainkey.justiceuk.onmicrosoft.com
-sip:
-  type: CNAME
-  value: sipdir.online.lync.com
 www:
   ttl: 300
   type: A

--- a/hostedzones/judicialconduct.gov.uk.yaml
+++ b/hostedzones/judicialconduct.gov.uk.yaml
@@ -38,20 +38,6 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=628112f5df71f7dae54240dd017ce101
-_sip._tls:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com
-    weight: 1
-_sip._tls.complaints:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com
-    weight: 1
 _sipfederationtls._tcp:
   type: SRV
   value:
@@ -139,12 +125,6 @@ selector2._domainkey.complaints:
   ttl: 600
   type: CNAME
   value: selector2-complaints-judicialconduct-gov-uk._domainkey.jcio.onmicrosoft.com
-sip:
-  type: CNAME
-  value: sipdir.online.lync.com
-sip.complaints:
-  type: CNAME
-  value: sipdir.online.lync.com
 www.complaints:
   ttl: 600
   type: CNAME

--- a/hostedzones/judicialombudsman.gov.uk.yaml
+++ b/hostedzones/judicialombudsman.gov.uk.yaml
@@ -41,13 +41,6 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=fc97333e0f757720f68cd18bcc560ec6
-_sip._tls:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com
-    weight: 1
 _sipfederationtls._tcp:
   type: SRV
   value:
@@ -92,9 +85,6 @@ selector1._domainkey:
 selector2._domainkey:
   type: CNAME
   value: selector2-judicialombudsman-gov-uk._domainkey.justiceuk.onmicrosoft.com
-sip:
-  type: CNAME
-  value: sipdir.online.lync.com
 www:
   ttl: 300
   type: CNAME

--- a/hostedzones/judiciary.uk.yaml
+++ b/hostedzones/judiciary.uk.yaml
@@ -142,13 +142,6 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=88b4c62db3d90a75b10f17f0efb20126
-_sip._tls:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com.
-    weight: 1
 _sipfederationtls._tcp:
   type: SRV
   value:
@@ -395,9 +388,6 @@ selector1._domainkey:
 selector2._domainkey:
   type: CNAME
   value: selector2-judiciary-uk._domainkey.justiceuk.onmicrosoft.com.
-sip:
-  type: CNAME
-  value: sipdir.online.lync.com.
 smeunpaid5wygnssk3dzyvjtodijdmlw._domainkey.elinks-jo-staging-email.elinks:
   type: CNAME
   value: smeunpaid5wygnssk3dzyvjtodijdmlw.dkim.amazonses.com

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -358,28 +358,6 @@ _sip._tcp.video:
       priority: 10
       target: px02.video.justice.gov.uk
       weight: 10
-_sip._tls:
-  ttl: 600
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com.
-    weight: 1
-_sip._tls.cshrcasework:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com
-    weight: 1
-_sip._tls.official:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com
-    weight: 1
 _sipfederationtls._tcp:
   ttl: 600
   type: SRV
@@ -1776,13 +1754,6 @@ service:
     - ns-1621.awsdns-10.co.uk.
     - ns-187.awsdns-23.com.
     - ns-978.awsdns-58.net.
-sip:
-  ttl: 600
-  type: CNAME
-  value: sipdir.online.lync.com.
-sip.cshrcasework:
-  type: CNAME
-  value: sipdir.online.lync.com
 sip.meet.video:
   ttl: 300
   type: A

--- a/hostedzones/lawcommission.gov.uk.yaml
+++ b/hostedzones/lawcommission.gov.uk.yaml
@@ -34,13 +34,6 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=4343bbedbf07cb2a94a7591249b4c9dc
-_sip._tls:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com
-    weight: 1
 _sipfederationtls._tcp:
   type: SRV
   value:
@@ -85,6 +78,3 @@ selector1._domainkey:
 selector2._domainkey:
   type: CNAME
   value: selector2-lawcommission-gov-uk._domainkey.justiceuk.onmicrosoft.com
-sip:
-  type: CNAME
-  value: sipdir.online.lync.com

--- a/hostedzones/ospt.gov.uk.yaml
+++ b/hostedzones/ospt.gov.uk.yaml
@@ -45,13 +45,6 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=507a481cc88850198bb9445c9f882b62
-_sip._tls:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com
-    weight: 1
 _sipfederationtls._tcp:
   type: SRV
   value:
@@ -100,9 +93,6 @@ selector1._domainkey:
 selector2._domainkey:
   type: CNAME
   value: selector2-ospt-gov-uk._domainkey.justiceuk.onmicrosoft.com
-sip:
-  type: CNAME
-  value: sipdir.online.lync.com
 soteria:
   - ttl: 300
     type: MX

--- a/hostedzones/paroleboard.gov.uk.yaml
+++ b/hostedzones/paroleboard.gov.uk.yaml
@@ -59,13 +59,6 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=d3c166db45a506d6876e8eb1bb857d37
-_sip._tls:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com
-    weight: 1
 _sipfederationtls._tcp:
   type: SRV
   value:
@@ -114,9 +107,6 @@ selector1._domainkey:
 selector2._domainkey:
   type: CNAME
   value: selector2-paroleboard-gov-uk._domainkey.digitalparole.onmicrosoft.com
-sip:
-  type: CNAME
-  value: sipdir.online.lync.com
 sopvpn:
   ttl: 300
   type: A

--- a/hostedzones/sentencingcouncil.gov.uk.yaml
+++ b/hostedzones/sentencingcouncil.gov.uk.yaml
@@ -38,13 +38,6 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=d4970def9fcfa09493764690e3fea748
-_sip._tls:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com.
-    weight: 1
 _sipfederationtls._tcp:
   type: SRV
   value:
@@ -89,6 +82,3 @@ selector1._domainkey:
 selector2._domainkey:
   type: CNAME
   value: selector2-sentencingcouncil-gov-uk._domainkey.justiceuk.onmicrosoft.com.
-sip:
-  type: CNAME
-  value: sipdir.online.lync.com.

--- a/hostedzones/test.justice.gov.uk.yaml
+++ b/hostedzones/test.justice.gov.uk.yaml
@@ -39,13 +39,6 @@ _dmarc.noreply:
   ttl: 300
   type: CNAME
   value: _dmarc_ttp_policy.justice.gov.uk
-_sip._tls:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com.
-    weight: 1
 _sipfederationtls._tcp:
   type: SRV
   value:
@@ -130,9 +123,6 @@ selector2._domainkey.fax:
   ttl: 300
   type: CNAME
   value: selector2-fax.test.justice.gov.uk._domainkey.justiceuk.onmicrosoft.com
-sip:
-  type: CNAME
-  value: sipdir.online.lync.com.
 smtp:
   ttl: 600
   type: A

--- a/hostedzones/ukgovwales.gov.uk.yaml
+++ b/hostedzones/ukgovwales.gov.uk.yaml
@@ -42,14 +42,6 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=17d1b3b0638bb374b0fae85e4a89e162
-_sip._tls:
-  ttl: 300
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com.
-    weight: 1
 _sipfederationtls._tcp:
   ttl: 300
   type: SRV
@@ -110,10 +102,6 @@ selector2._domainkey:
   ttl: 300
   type: CNAME
   value: selector2-ukgovwales-gov-uk._domainkey.justiceuk.onmicrosoft.com
-sip:
-  ttl: 300
-  type: CNAME
-  value: sipdir.online.lync.com.
 www:
   ttl: 300
   type: CNAME

--- a/hostedzones/victimscommissioner.org.uk.yaml
+++ b/hostedzones/victimscommissioner.org.uk.yaml
@@ -56,13 +56,6 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=382e5b84ba072da4451a6081d72d60b4
-_sip._tls:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com
-    weight: 1
 _sipfederationtls._tcp:
   type: SRV
   value:
@@ -139,9 +132,6 @@ selector1._domainkey:
 selector2._domainkey:
   type: CNAME
   value: selector2-victimscommissioner-org-uk._domainkey.justiceuk.onmicrosoft.com
-sip:
-  type: CNAME
-  value: sipdir.online.lync.com
 www:
   ttl: 300
   type: CNAME

--- a/hostedzones/yjb.gov.uk.yaml
+++ b/hostedzones/yjb.gov.uk.yaml
@@ -105,13 +105,6 @@ _mta-sts.youthjusticepp:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=d2ee1a37ca7e90b96d3b0be7d64d9b50
-_sip._tls:
-  type: SRV
-  value:
-    port: 443
-    priority: 100
-    target: sipdir.online.lync.com.
-    weight: 1
 _sipfederationtls._tcp:
   type: SRV
   value:
@@ -310,9 +303,6 @@ selfservice.y2a:
 servicedesk:
   type: NS
   values: [ns1.gradwellcloud.com., ns2.gradwellcloud.com.]
-sip:
-  type: CNAME
-  value: sipdir.online.lync.com.
 smtp.y2a:
   type: A
   value: 83.151.208.61


### PR DESCRIPTION
## 👀 Purpose

- We have been alerted by CDDO that we have a number of dangling DNS records. These records all related to legacy messaging service that no longer exists. The PR removes all the dangling DNS records to mitigate vulnerabilities.

## ♻️ What's changed

- Remove multiple SRV and CNAME records

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/8MOsOc05bEQ/m/n5rYdFAeAQAJ)