### PR TITLE
Add Google Site Verification TXT record to `devl.justice.gov.uk`

### DIFF
--- a/hostedzones/devl.justice.gov.uk.yaml
+++ b/hostedzones/devl.justice.gov.uk.yaml
@@ -12,7 +12,9 @@
       - ns-358.awsdns-44.com.
       - ns-965.awsdns-56.net.
   - type: TXT
-    value: v=spf1 include:spf.protection.outlook.com -all
+    values: 
+      - v=spf1 include:spf.protection.outlook.com -all
+      - google-site-verification=HhPu9-ILo7FvJ9FGjbGLyiavc4F8Pqt5tgqozUg3ah0
 _735b486553cdfa713eebbd5f2ff3d69b.mta-sts:
   ttl: 60
   type: CNAME

--- a/hostedzones/devl.justice.gov.uk.yaml
+++ b/hostedzones/devl.justice.gov.uk.yaml
@@ -12,7 +12,7 @@
       - ns-358.awsdns-44.com.
       - ns-965.awsdns-56.net.
   - type: TXT
-    values: 
+    values:
       - v=spf1 include:spf.protection.outlook.com -all
       - google-site-verification=HhPu9-ILo7FvJ9FGjbGLyiavc4F8Pqt5tgqozUg3ah0
 _735b486553cdfa713eebbd5f2ff3d69b.mta-sts:

--- a/hostedzones/digital.justice.gov.uk.yaml
+++ b/hostedzones/digital.justice.gov.uk.yaml
@@ -313,7 +313,6 @@ test:
       - google-site-verification=eKrQOC2iPS1lEVnT_dPfGq4GGfEiWkICwBIQKDMK24s
       - v=spf1 include:spf.protection.outlook.com include:_spf.google.com ip4:18.130.205.7
         ~all
-      - google-site-verification=HhPu9-ILo7FvJ9FGjbGLyiavc4F8Pqt5tgqozUg3ah0
 w3lfdwhi4uimdhfijhgb7slpiossuoz7._domainkey:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR moves a Google Site verification TXT record from test.digital.justice.gov.uk to devl.justice.gov.uk. Service Team have decided to use the different domain for testing.

## ♻️ What's changed

- Remove Google Site Verification value from `test.digital.justice.gov.uk` `TXT` record
- Add Google Site Verification value from `devl.justice.gov.uk` `TXT` record