### PR TITLE
Remove delegation for webapps.judiciary.gov.uk

### DIFF
--- a/hostedzones/judiciary.gov.uk.yaml
+++ b/hostedzones/judiciary.gov.uk.yaml
@@ -130,14 +130,6 @@ smtp:
   ttl: 600
   type: A
   value: 80.86.35.81
-webapps:
-  ttl: 600
-  type: NS
-  values:
-    - ns-1428.awsdns-50.org.
-    - ns-1586.awsdns-06.co.uk.
-    - ns-653.awsdns-17.net.
-    - ns-92.awsdns-11.com.
 www:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR removes delegation to a hostedzone no longer in use. Delegation removed to mitigate security risk.

## ♻️ What's changed

- Delete `NS` record for webapps.judiciary.gov.uk

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/KM2EDv1rUa4/m/U6ygieg5CAAJ)