### PR TITLE
Add new DNS record

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -77,7 +77,7 @@ _935f4ad292e31cb21e5bf6043b20a2bf.securecodewarrior:
   ttl: 300
   type: CNAME
   value: _f65a4f48e9990c0858b5134cdc625b9b.kzhndfqvzk.acm-validations.aws.
- _985AF129AE87A7054E017224D833BBD2.staging.hmpps-canine-management:
+_985AF129AE87A7054E017224D833BBD2.staging.hmpps-canine-management:
   ttl: 300
   type: CNAME
   value: 964CBF6535706E1C3C237E53883FD2CE.7BD4CFCB74A84C8E2D7C301A0386EC67.bc05f4557ebe7cb8b79d.sectigo.com.

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -77,6 +77,10 @@ _935f4ad292e31cb21e5bf6043b20a2bf.securecodewarrior:
   ttl: 300
   type: CNAME
   value: _f65a4f48e9990c0858b5134cdc625b9b.kzhndfqvzk.acm-validations.aws.
+ _985AF129AE87A7054E017224D833BBD2.staging.hmpps-canine-management:
+  ttl: 300
+  type: CNAME
+  value: 964CBF6535706E1C3C237E53883FD2CE.7BD4CFCB74A84C8E2D7C301A0386EC67.bc05f4557ebe7cb8b79d.sectigo.com.
 _36085f4d854229b89162cf35526735a4.veracode:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
To validate a new certificate, service.justice.gov.uk.yaml has been updated with a new DNS record for staging.hmpps-canine-management.