### PR TITLE
Remove `nac.justice.gov.uk` delegations

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -801,14 +801,6 @@ dev.cjscp:
   ttl: 600
   type: A
   value: 83.151.216.178
-dev.nac:
-  ttl: 300
-  type: NS
-  values:
-    - ns-1116.awsdns-11.org.
-    - ns-1793.awsdns-32.co.uk.
-    - ns-508.awsdns-63.com.
-    - ns-722.awsdns-26.net.
 devbuild.cjscp:
   ttl: 600
   type: A
@@ -1384,14 +1376,6 @@ mw7c6bnh4g4z47lipedqspbq4pdydivs._domainkey.certificates:
   ttl: 1800
   type: CNAME
   value: mw7c6bnh4g4z47lipedqspbq4pdydivs.dkim.amazonses.com
-nac:
-  ttl: 300
-  type: NS
-  values:
-    - ns-1446.awsdns-52.org.
-    - ns-2001.awsdns-58.co.uk.
-    - ns-543.awsdns-03.net.
-    - ns-57.awsdns-07.com.
 network:
   ttl: 300
   type: TXT
@@ -1556,14 +1540,6 @@ pre-recorded-evidence:
     - ns2-02.azure-dns.net.
     - ns3-02.azure-dns.org.
     - ns4-02.azure-dns.info.
-prep.nac:
-  ttl: 300
-  type: NS
-  values:
-    - ns-1494.awsdns-58.org.
-    - ns-1610.awsdns-09.co.uk.
-    - ns-400.awsdns-50.com.
-    - ns-779.awsdns-33.net.
 preprod.cjscp:
   ttl: 600
   type: A


### PR DESCRIPTION
## 👀 Purpose

- This PR removed dangling NS delegations. Theses delegations are no longer is use and services have been delegated to new `service.justice.gov.uk` subdomains.

## ♻️ What's changed

- Delete NS Record `dev.nac.justice.gov.uk`
- Delete NS Record `prep.nac.justice.gov.uk`
- Delete NS Record `nac.justice.gov.uk`

## 📝 Notes

- [Security Alert](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/z5XJUztMXVo/m/DQPsOJM7AQAJ)
- [Slack thread](https://mojdt.slack.com/archives/C026AFE617T/p1725530856334839)
- [Confirmation of new domains in use](https://mojdt.slack.com/archives/C01TQDMMC87/p1633415332058900)