### PR TITLE
Delegate `advance-into-justice.service.justice.gov.uk`

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -351,9 +351,13 @@ access.platforms:
     - ns-325.awsdns-40.com.
     - ns-674.awsdns-20.net.
 advance-into-justice:
-  ttl: 300
-  type: CNAME
-  value: d2zug2r9gue1ql.cloudfront.net.
+  ttl: 86400
+  type: NS
+  values:
+    - ns-328.awsdns-41.com.
+    - ns-1850.awsdns-39.co.uk.
+    - ns-1059.awsdns-04.org.
+    - ns-1016.awsdns-63.net.
 analytical-evidence-library:
   ttl: 300
   type: NS


### PR DESCRIPTION
## 👀 Purpose

- This PR delegates `advance-into-justice.service.justice.gov.uk` to Cloud Platform.

## ♻️ What's changed

- Update DNS type and value from CNAME to NS for `advance-into-justice.service.justice.gov.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/h9oshjADj14/m/noNXmj6kAwAJ)