### PR TITLE
Add CNAMES to ima-citizensrights.org.uk

### DIFF
--- a/hostedzones/ima-citizensright.org.uk.yaml
+++ b/hostedzones/ima-citizensright.org.uk.yaml
@@ -24,6 +24,10 @@
   - ttl: 300
     type: TXT
     value: v=spf1 -all
+129688.ima-citizensrights.org.uk:
+  ttl: 300
+  type: CNAME
+  value: sendgrid.net
 '*._domainkey':
   ttl: 300
   type: TXT
@@ -32,10 +36,6 @@ _dmarc:
   ttl: 300
   type: TXT
   value: v=DMARC1\;p=reject\;sp=reject\;rua=mailto:dmarc-rua@dmarc.service.gov.uk\;
-129688.ima-citizensrights.org.uk:
-  ttl: 300
-  type: CNAME
-  value: sendgrid.net
 mhq1449.ima-citizensrights.org.uk:
   ttl: 300
   type: CNAME

--- a/hostedzones/ima-citizensright.org.uk.yaml
+++ b/hostedzones/ima-citizensright.org.uk.yaml
@@ -32,3 +32,23 @@ _dmarc:
   ttl: 300
   type: TXT
   value: v=DMARC1\;p=reject\;sp=reject\;rua=mailto:dmarc-rua@dmarc.service.gov.uk\;
+129688.ima-citizensrights.org.uk:
+  ttl: 300
+  type: CNAME
+  value: sendgrid.net
+mhq1449.ima-citizensrights.org.uk:
+  ttl: 300
+  type: CNAME
+  value: u129688.wl189.sendgrid.net
+mhq1449link.ima-citizensrights.org.uk:
+  ttl: 300
+  type: CNAME
+  value: sendgrid.net
+s1._domainkey.ima-citizensrights.org.uk:
+  ttl: 300
+  type: CNAME
+  value: s1.domainkey.u129688.wl189.sendgrid.net
+s2._domainkey.ima-citizensrights.org.uk:
+  ttl: 300
+  type: CNAME
+  value: s2.domainkey.u129688.wl189.sendgrid.net


### PR DESCRIPTION
This PR is to add the following CNAMES to ima-citizensrights.org.uk:

Type               Host                                                                Data
cname             mhq1449.ima-citizensrights.org.uk             u129688.wl189.sendgrid.net
cname             s1._domainkey.ima-citizensrights.org.uk            s1.domainkey.u129688.wl189.sendgrid.net
cname             s2._domainkey.ima-citizensrights.org.uk            s2.domainkey.u129688.wl189.sendgrid.net
cname             mhq1449link.ima-citizensrights.org.uk            sendgrid.net
cname             129688.ima-citizensrights.org.uk                sendgrid.net