### PR TITLE
Add certificate validation TXT record to `judiciary.uk`

### DIFF
--- a/hostedzones/judiciary.uk.yaml
+++ b/hostedzones/judiciary.uk.yaml
@@ -25,6 +25,7 @@
       - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32 ip4:78.31.108.141 include:spf.protection.outlook.com
         include:ciphr247.com -all
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
+      - rfpi1va7dtqmdgthssu2skjjqf
 5vl4vla56j76p3obneqqnjelrynl2kiv._domainkey.elinks-staging-email.elinks:
   type: CNAME
   value: 5vl4vla56j76p3obneqqnjelrynl2kiv.dkim.amazonses.com


### PR DESCRIPTION
## 👀 Purpose

- This PR add a TLS certificate validation record to the `judiciary.uk` domain. This will allow a new TLS certificate to be generated.

## ♻️ What's changed

- Adds TXT record to `judiciary.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/1f9hFbWL4SA/m/E-17Vu6gBQAJ)