### PR TITLE
Add laa-debt-collection record

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -934,6 +934,14 @@ laa-crime:
   ttl: 300
   type: TXT
   value: OSSRH-90962
+laa-debt-collection:
+  ttl: 300
+  type: NS
+  values:
+    - ns-145.awsdns-18.com
+    - nns-1471.awsdns-55.org
+    - nns-1920.awsdns-48.co.uk
+    - nns-857.awsdns-43.net
 laa-fee-calculator:
   ttl: 300
   type: NS


### PR DESCRIPTION
Adds a record to service.justice.gov.uk for laa-debt-collection:

 - [ns-145.awsdns-18.com](http://ns-145.awsdns-18.com/)
 - [nns-1471.awsdns-55.org](http://nns-1471.awsdns-55.org/)
 - [nns-1920.awsdns-48.co.uk](http://nns-1920.awsdns-48.co.uk/)
 - [nns-857.awsdns-43.net](http://nns-857.awsdns-43.net/)