### PR TITLE
Remove unused govfsl.com spf rules

### DIFF
--- a/hostedzones/govfsl.com.yaml
+++ b/hostedzones/govfsl.com.yaml
@@ -19,9 +19,7 @@
       - MS=ms10443166
       - apple-domain-verification=X27AYsxWvqjiHs8k
       - google-site-verification=y13dLG-4NRFPZgOO6aIVATIWaBcDAsmAVTy-_TD5M2M
-      - v=spf1 include:_spf.google.com include:carillionplc.com include:spf.protection.outlook.com
-        include:spf_c.oracle.com include:spf_c.oraclecloud.com ip4:188.65.119.39 ip4:188.65.119.42 ip4:87.247.244.98
-        ip4:195.62.28.68 ip4:185.24.97.25 -all
+      - v=spf1 include:spf.protection.outlook.com include:spf_c.oracle.com include:spf_c.oraclecloud.com ip4:188.65.119.39 ip4:188.65.119.42 ip4:87.247.244.98 ip4:195.62.28.68 ip4:185.24.97.25 -all
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
       - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
 _94027e3232a87bef15c3cfb7834ff05c.mta-sts:


### PR DESCRIPTION
## 👀 Purpose

- This PR removes old rules in the govfsl.com spf TXT record. These email services are no longer used so should not be included in spf rules.

## ♻️ What's changed

- Update TXT record govfsl.com

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/0KHdWyYrZ8U/m/qebEmd29AAAJ)