### PR TITLE
Update `mail1.criminalappealoffice.justice.gov.uk` TXT record

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -14,7 +14,7 @@
   - ttl: 600
     type: TXT
     values:
-      - 2023100512295066wskn0790wjkn68f9l9rq5klf9siskhuhue56wicgicbnwr3b
+      - 2024092711172121ni7tnf9yvm6mf9k5z9ahrqdpmoctc1k9lpkic5vaq1fvwqur
       - BTUhp9Uq4ukuVfeGN5jrIsf32ll79sBSGRw0qc+3XoO2ewFCNNdhMIMb+tj5xdom8y7CWGgxtthH/9mE/p8+Yg==
       - Dynatrace-site-verification=b3468c91-d00e-4550-b156-92df0139d471__5ae4ot4eoj67h6tepojhf93del
       - MS=ms58266631
@@ -1255,7 +1255,7 @@ mail1.criminalappealoffice:
     value: 178.248.34.43
   - ttl: 300
     type: TXT
-    value: 2023100512295066wskn0790wjkn68f9l9rq5klf9siskhuhue56wicgicbnwr3b
+    value: 2024092711172121ni7tnf9yvm6mf9k5z9ahrqdpmoctc1k9lpkic5vaq1fvwqur
 mail2:
   ttl: 600
   type: A


### PR DESCRIPTION
## 👀 Purpose

- This PR updates the existing `mail1.criminalappealoffice.justice.gov.uk` and `justice.gov.uk` TXT records with new certificate validation records.

## ♻️ What's changed

- Update TXT record `justice.gov.uk`
- Update TXT record `mail1.criminalappealoffice.justice.gov.uk`