### PR TITLE
Add spf and DKIM for `fleetmanagementteam.justice.gov.uk`

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -937,6 +937,10 @@ find-legal-advice:
       - ns-1392.awsdns-46.org.
       - ns-180.awsdns-22.com.
       - ns-2041.awsdns-63.co.uk.
+fleetmanagementteam:
+  ttl: 300
+  type: txt
+  value: v=spf1 spf.hosted.jaama.co.uk ~all
 fmk7xlvhjfqqruhiytlb6434lcykrduv._domainkey:
   ttl: 300
   type: TXT
@@ -1114,10 +1118,10 @@ intranet:
     - ns-1773.awsdns-29.co.uk.
     - ns-697.awsdns-23.net.
     - ns-77.awsdns-09.com.
-jaama._domainkey:
+jaama._domainkey.fleetmanagementteam:
   ttl: 300
   type: TXT
-  value: v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCtZJY6Zx60GV9lIDjdeeu6qGU6/MhFSu2gvAyXo0LUzFiVMG0y1E1S1HCQh0exXOwzqh+G4IyjZieeeGWdVcgITAsMRGDfc+kQM8Mmw6USAiNzfHEf4vjUYkzg+a5AI3BzUPpzNgHDwvM1j2jtUO76NwEKgtP0Wg4bRCNZBzqtfQIDAQAB
+  value: v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDeFclAkZdVjMAlrr5kkUVGNvJcb0DWEJngIMSNd4ApsfzMSjYVV+HkKRlvCIP8eiefG0guBfkz/f8MHbut+BwvLNM7IKLcHOrADKJDq5IVBpFtxLy5CuFIgdM0HQwmyweckVqEjLkQEIWVRTTb5FAkuVHFqfwSTPTbJoCqY41rcwIDAQAB
 jira.cjscp:
   ttl: 600
   type: CNAME

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -939,7 +939,7 @@ find-legal-advice:
       - ns-2041.awsdns-63.co.uk.
 fleetmanagementteam:
   ttl: 300
-  type: txt
+  type: TXT
   value: v=spf1 spf.hosted.jaama.co.uk ~all
 fmk7xlvhjfqqruhiytlb6434lcykrduv._domainkey:
   ttl: 300


### PR DESCRIPTION
## 👀 Purpose

- The PR adds spf and DKIM records for the new email domain `fleetmanagementteam.justice.gov.uk`. It also removes the original DKIM record `jaama._domainkey.justice.gov.uk`, which is no longer required.

## ♻️ What's changed

- Add TXT record `fleetmanagementteam.justice.gov.uk`
- Add TXT record `jaama._domainkey.fleetmanagementteam.justice.gov.uk`
- Remove TXT record `jaama._domainkey.justice.gov.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/yYC35Pa_MqE/m/8b5OXrD3AQAJ)