### PR TITLE
Update fleetmanagement value

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -940,7 +940,7 @@ find-legal-advice:
 fleetmanagementteam:
   ttl: 300
   type: TXT
-  value: v=spf1 spf.hosted.jaama.co.uk ~all
+  value: v=spf1 include:spf.hosted.jaama.co.uk ~all
 fmk7xlvhjfqqruhiytlb6434lcykrduv._domainkey:
   ttl: 300
   type: TXT


### PR DESCRIPTION
Update the justice.gov.uk hosted zone record for fleetmanagement:

from: v=spf1 [spf.hosted.jaama.co.uk](http://spf.hosted.jaama.co.uk/) ~all
to: v=spf1 include:[spf.hosted.jaama.co.uk](http://spf.hosted.jaama.co.uk/) ~all