### PR TITLE
Remove dangling DNS rcords

### DIFF
--- a/hostedzones/judicialconduct.gov.uk.yaml
+++ b/hostedzones/judicialconduct.gov.uk.yaml
@@ -45,13 +45,6 @@ _sipfederationtls._tcp:
     priority: 100
     target: sipfed.online.lync.com
     weight: 1
-_sipfederationtls._tcp.complaints:
-  type: SRV
-  value:
-    port: 5061
-    priority: 100
-    target: sipfed.online.lync.com
-    weight: 1
 _smtp._tls:
   ttl: 300
   type: TXT
@@ -94,12 +87,6 @@ fp01._domainkey:
   ttl: 300
   type: TXT
   value: v=DKIM1\; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCN/Dnp6gO1PJVQgLljNpkkvVUH/G04C2QkC28j8ddX13V7MAvDWpCxnUfTPy8C27njUImSa8b2TwyeA0P2ONPHQhW652tSxZa0+VT2b5qRFhne3UigZEeKhix988mhlOTO+6PN4+JR7MPXSeE0iGGPWm8m4JsxeaVvwN0XC92yvQIDAQAB\;
-lyncdiscover:
-  type: CNAME
-  value: webdir.online.lync.com
-lyncdiscover.complaints:
-  type: CNAME
-  value: webdir.online.lync.com
 msoid:
   type: CNAME
   value: clientconfig.microsoftonline-p.net

--- a/hostedzones/paroleboard.gov.uk.yaml
+++ b/hostedzones/paroleboard.gov.uk.yaml
@@ -63,13 +63,6 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=d3c166db45a506d6876e8eb1bb857d37
-_sipfederationtls._tcp:
-  type: SRV
-  value:
-    port: 5061
-    priority: 100
-    target: sipfed.online.lync.com
-    weight: 1
 _smtp._tls:
   ttl: 300
   type: TXT
@@ -87,9 +80,6 @@ enterpriseenrollment:
 enterpriseregistration:
   type: CNAME
   value: enterpriseregistration.windows.net
-lyncdiscover:
-  type: CNAME
-  value: webdir.online.lync.com
 msoid:
   type: CNAME
   value: clientconfig.microsoftonline-p.net


### PR DESCRIPTION
## 👀 Purpose

- This PR removes some dangling DNS records

## ♻️ What's changed

- Removes `_sipfederationtls._tcp.complaints.judicialconduct.gov.uk`
- Removes `lyncdiscover.judicialconduct.gov.uk`
- Removes `lyncdiscover.complaints.judicialconduct.gov.uk`
- Removes `_sipfederationtls._tcp.paroleboard.gov.uk`
- Removes `lyncdiscover.paroleboard.gov.uk`

## 📝 Notes

- [Alert Notice](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/8MOsOc05bEQ/m/n5rYdFAeAQAJ)