### PR TITLE
Add new Cloudfront CNAMEs

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1690,6 +1690,14 @@ track-a-query:
     - ns-166.awsdns-20.com.
     - ns-1947.awsdns-51.co.uk.
     - ns-778.awsdns-33.net.
+training.creatingfutureopportunities:
+  ttl: 300
+  type: CNAME
+  value: d2xa34imt80u6b.cloudfront.net
+training.manage-external-funded-offender-provision:
+  ttl: 300
+  type: CNAME
+  value: d2xa34imt80u6b.cloudfront.net
 training-preproduction.manage-external-funded-offender-provision:
   ttl: 942942942
   type: Route53Provider/ALIAS

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1690,14 +1690,6 @@ track-a-query:
     - ns-166.awsdns-20.com.
     - ns-1947.awsdns-51.co.uk.
     - ns-778.awsdns-33.net.
-training.creatingfutureopportunities:
-  ttl: 300
-  type: CNAME
-  value: d2xa34imt80u6b.cloudfront.net
-training.manage-external-funded-offender-provision:
-  ttl: 300
-  type: CNAME
-  value: d2xa34imt80u6b.cloudfront.net
 training-preproduction.manage-external-funded-offender-provision:
   ttl: 942942942
   type: Route53Provider/ALIAS
@@ -1706,6 +1698,14 @@ training-preproduction.manage-external-funded-offender-provision:
     hosted-zone-id: Z2FDTNDATAQYW2
     name: d3vok0bwimv2ce.cloudfront.net.
     type: A
+training.creatingfutureopportunities:
+  ttl: 300
+  type: CNAME
+  value: d2xa34imt80u6b.cloudfront.net
+training.manage-external-funded-offender-provision:
+  ttl: 300
+  type: CNAME
+  value: d2xa34imt80u6b.cloudfront.net
 trg.list-assist:
   ttl: 300
   type: A


### PR DESCRIPTION
## 👀 Purpose

- This PR adds two new CNAMES for `training.creatingfutureopportunities.service.justice.gov.uk` and `training.manage-external-funded-offender-provision.service.justice.gov.uk`.

## ♻️ What's changed

- Add CNAME `training.creatingfutureopportunities.service.justice.gov.uk`
- Add CNAME `training.manage-external-funded-offender-provision.service.justice.gov.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/DtAQ4a9DMZE/m/rrdoJhooAgAJ)
-