### PR TITLE
Delete claonlineadvice.justice.gov.uk subdomains

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -600,10 +600,6 @@ cjsm.secure-email.ppud:
   - ttl: 300
     type: TXT
     value: v=spf1 ip4:18.169.26.236 ip4:3.9.111.144 ~all
-claonlineadvice:
-  ttl: 600
-  type: A
-  value: 81.105.223.242
 cms-staging.court.store:
   ttl: 300
   type: A
@@ -1873,10 +1869,6 @@ uat.ppud:
     hosted-zone-id: ZHURV8PSTC4K8
     name: internal-ppud-alb-1479410725.eu-west-2.elb.amazonaws.com.
     type: A
-uatclaonlineadvice:
-  ttl: 600
-  type: A
-  value: 81.105.223.243
 ul5ni2ujr4yk2y5txdb6rxzmj6ko3hw2._domainkey.uat.cshrcaseworkcma:
   ttl: 300
   type: CNAME
@@ -1961,10 +1953,6 @@ www.cjscp:
   ttl: 600
   type: A
   value: 83.151.216.180
-www.claonlineadvice:
-  ttl: 600
-  type: A
-  value: 89.185.223.242
 www.drs:
   ttl: 600
   type: A
@@ -2037,10 +2025,6 @@ www.staff-staging.court.store:
   ttl: 300
   type: A
   value: 18.168.187.252
-www.uatclaonlineadvice:
-  ttl: 600
-  type: A
-  value: 81.105.223.243
 xhibit:
   ttl: 600
   type: NS


### PR DESCRIPTION
## 👀 Purpose

- This PR removes some unused claonlineadvice.justice.gov.uk subdomains. The old domains are associated to IP addresses that are vulnerable and pose a security risk. Removal of the records mitigates any risks.

## ♻️ What's changed

- Delete `claonlineadvice.justice.gov.uk`
- Delete `www.claonlineadvice.justice.gov.uk`
- Delete `uatclaonlineadvice.justice.gov.uk`
- Delete `www.uatclaonlineadvice.justice.gov.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/zNQiA9b1G3s/m/ncWGgqRZBAAJ)