### PR TITLE
Delegate `legalaidlearning.justice.gov.uk` to Cloud Platform

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -1172,7 +1172,7 @@ legalaidlearning:
   ttl: 86400
   type: NS
   values:
-    - ns-1947.awsdns-51.co.uk. 
+    - ns-1947.awsdns-51.co.uk.
     - ns-823.awsdns-38.net.
     - ns-1373.awsdns-43.org.
     - ns-304.awsdns-38.com.

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -1169,9 +1169,13 @@ legalaidcalculator:
   type: CNAME
   value: legal-aid-checker.justice.gov.uk.
 legalaidlearning:
-  ttl: 300
-  type: CNAME
-  value: t12h.cloudlp.net
+  ttl: 86400
+  type: NS
+  values:
+    - ns-1947.awsdns-51.co.uk. 
+    - ns-823.awsdns-38.net.
+    - ns-1373.awsdns-43.org.
+    - ns-304.awsdns-38.com.
 legalaidtraining:
   ttl: 600
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- The PR delegates `legalaidlearning.justice.gov.uk` to Cloud Platform.

## ♻️ What's changed

- Update CNAME `legalaidlearning.justice.gov.uk` to NS Records

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/wDWBA14dZtg/m/EAxXcIejAgAJ)