### PR TITLE
♻️  Search Whole File for Sectigo + Ignore Edge Cases

### DIFF
--- a/remove_sectigo_blocks.py
+++ b/remove_sectigo_blocks.py
@@ -12,12 +12,28 @@ yaml.indent(
 yaml.explicit_start = True  # Always start the YAML document with '---'
 
 
+def should_ignore_block(value):
+    value_str = str(value).lower()
+    ignored_items = [
+        "courtfinder.demo",
+        "courtfinder.staging",
+        "public.demo",
+        "public.staging",
+        "staff.demo",
+        "staff.staging",
+    ]
+    if any(item in value_str for item in ignored_items):
+        return True
+
+
 def find_and_remove_sectigo_block(data, parent_key=None):
     found_any = False
 
     if isinstance(data, dict):
         keys_to_remove = []
         for key, value in data.items():
+            if should_ignore_block(key):
+                continue
             if "sectigo" in str(value).lower():
                 keys_to_remove.append(key)
                 found_any = True
@@ -30,6 +46,8 @@ def find_and_remove_sectigo_block(data, parent_key=None):
     elif isinstance(data, list):
         items_to_remove = []
         for i, item in enumerate(data):
+            if should_ignore_block(i):
+                continue
             _, changed = find_and_remove_sectigo_block(item, parent_key)
             if changed:
                 items_to_remove.append(i)


### PR DESCRIPTION
This pull request includes significant improvements to the `remove_sectigo_blocks.py` script, enhancing its functionality and readability. The most important changes include the addition of a function to ignore specific blocks, modifications to the block removal logic, and updates to the process function to provide clearer output.

Enhancements to block handling:

* [`remove_sectigo_blocks.py`](diffhunk://#diff-75b424ff28415166eb1955feea495dc1288ea0915f08286c9d694a8d69b6dc13R15-R69): Added the `should_ignore_block` function to ignore specific blocks based on predefined criteria.
* [`remove_sectigo_blocks.py`](diffhunk://#diff-75b424ff28415166eb1955feea495dc1288ea0915f08286c9d694a8d69b6dc13R15-R69): Modified the `find_and_remove_sectigo_block` function to utilize the `should_ignore_block` function and improve the logic for identifying and removing blocks. This change includes tracking whether any blocks were found and removed.

Improvements to process function:

* [`remove_sectigo_blocks.py`](diffhunk://#diff-75b424ff28415166eb1955feea495dc1288ea0915f08286c9d694a8d69b6dc13R15-R69): Updated the `process_yaml_file` function to provide a more informative message when blocks containing 'sectigo' are removed.