### PR TITLE
Update record

### DIFF
--- a/hostedzones/devl.justice.gov.uk.yaml
+++ b/hostedzones/devl.justice.gov.uk.yaml
@@ -13,7 +13,7 @@
       - ns-965.awsdns-56.net.
   - type: TXT
     values:
-      - v=spf1 include:spf.protection.outlook.com -all
+      - v=spf1 include:spf.protection.outlook.com include:smtp-relay.dev.staff.service.justice.gov.uk -all
       - google-site-verification=HhPu9-ILo7FvJ9FGjbGLyiavc4F8Pqt5tgqozUg3ah0
 _735b486553cdfa713eebbd5f2ff3d69b.mta-sts:
   ttl: 60


### PR DESCRIPTION
[DNS Request #73](https://github.com/ministryofjustice/operations-engineering-dns-issues/issues/73)

Request Details: Can we have SPF record updated for "devl.justice.gov.uk" domain to the following

v=spf1 include:spf.protection.outlook.com include:smtp-relay.dev.staff.service.justice.gov.uk -all

existing record is:
v=spf1 include:spf.protection.outlook.com -all