### PR TITLE
Nullify dsd.io MX record

### DIFF
--- a/hostedzones/dsd.io.yaml
+++ b/hostedzones/dsd.io.yaml
@@ -3,8 +3,8 @@
   - ttl: 1800
     type: MX
     value:
-      exchange: inbound-smtp.eu-west-1.amazonaws.com
-      preference: 10
+      exchange: .
+      preference: 0
   - ttl: 300
     type: NS
     values:


### PR DESCRIPTION
## 👀 Purpose

This PR nullifies the `dsd.io` MX record. The `dsd.io` domain should no longer be in use by any services. This change will stop emails being sent from `@dsd.io` email services. 

## ♻️ What's changed

- Update `MX` record `dsd.io`