### PR TITLE
Update alias carestandardstribunal.gov.uk

### DIFF
--- a/hostedzones/carestandardstribunal.gov.uk.yaml
+++ b/hostedzones/carestandardstribunal.gov.uk.yaml
@@ -11,8 +11,8 @@
     type: Route53Provider/ALIAS
     value:
       evaluate-target-health: false
-      hosted-zone-id: Z32O12XQLNTSW2
-      name: tribunals-nginx-1184258455.eu-west-1.elb.amazonaws.com.
+      hosted-zone-id: ZHURV8PSTC4K8
+      name: tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com.
       type: A
 _asvdns-8d00d173-2054-4f62-a26c-ac866af546e1:
   ttl: 300


### PR DESCRIPTION
Request to change the `carestandardstribunal.gov.uk` A record:

From:
name = "[tribunals-nginx-1184258455.eu-west-1.elb.amazonaws.com](http://tribunals-nginx-1184258455.eu-west-1.elb.amazonaws.com/)"
zone_id = "Z32O12XQLNTSW2"

To:
name = "[tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com](http://tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com/)"
zone_id = "ZHURV8PSTC4K8"