### PR TITLE
Change A record info

### DIFF
--- a/hostedzones/immigrationservicestribunal.gov.uk.yaml
+++ b/hostedzones/immigrationservicestribunal.gov.uk.yaml
@@ -11,8 +11,8 @@
     type: Route53Provider/ALIAS
     value:
       evaluate-target-health: false
-      hosted-zone-id: Z32O12XQLNTSW2
-      name: tribunals-nginx-1184258455.eu-west-1.elb.amazonaws.com.
+      hosted-zone-id: ZHURV8PSTC4K8
+      name: tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com.
       type: A
 _dmarc:
   ttl: 300

--- a/hostedzones/informationtribunal.gov.uk.yaml
+++ b/hostedzones/informationtribunal.gov.uk.yaml
@@ -11,8 +11,8 @@
     type: Route53Provider/ALIAS
     value:
       evaluate-target-health: false
-      hosted-zone-id: Z32O12XQLNTSW2
-      name: tribunals-nginx-1184258455.eu-west-1.elb.amazonaws.com.
+      hosted-zone-id: ZHURV8PSTC4K8
+      name: tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com.
       type: A
 _dmarc:
   ttl: 300

--- a/hostedzones/osscsc.gov.uk.yaml
+++ b/hostedzones/osscsc.gov.uk.yaml
@@ -11,8 +11,8 @@
     type: Route53Provider/ALIAS
     value:
       evaluate-target-health: false
-      hosted-zone-id: Z32O12XQLNTSW2
-      name: tribunals-nginx-1184258455.eu-west-1.elb.amazonaws.com.
+      hosted-zone-id: ZHURV8PSTC4K8
+      name: tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com.
       type: A
 _dmarc:
   ttl: 300

--- a/hostedzones/transporttribunal.gov.uk.yaml
+++ b/hostedzones/transporttribunal.gov.uk.yaml
@@ -11,8 +11,8 @@
     type: Route53Provider/ALIAS
     value:
       evaluate-target-health: false
-      hosted-zone-id: Z32O12XQLNTSW2
-      name: tribunals-nginx-1184258455.eu-west-1.elb.amazonaws.com.
+      hosted-zone-id: ZHURV8PSTC4K8
+      name: tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com.
       type: A
 _dmarc:
   ttl: 300


### PR DESCRIPTION
4 more A record changes for the nginx migration:

- immigrationservicestribunal.gov.uk
- informationtribunal.gov.uk
- osscsc.gov.uk
- transporttribunal.gov.uk

Updated to:

hosted-zone-id: ZHURV8PSTC4K8
name: tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com.