### PR TITLE
:sparkles: Delegate change-dns to Cloud Platform

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -450,6 +450,14 @@ ccms-ebs:
     - ns-1743.awsdns-25.co.uk.
     - ns-22.awsdns-02.com.
     - ns-760.awsdns-31.net.
+change-dns:
+  ttl: 300
+  type: NS
+  values:
+    - ns-381.awsdns-47.com.
+    - ns-1532.awsdns-63.org.
+    - ns-792.awsdns-35.net.
+    - ns-1642.awsdns-13.co.uk.
 check-clients-details-using-hmrc-data:
   ttl: 300
   type: NS


### PR DESCRIPTION
This pull request includes a change to the DNS configuration in the `hostedzones/service.justice.gov.uk.yaml` file. The most important change involves updating the DNS records for the `ccms-ebs` service.

DNS Configuration Update:

* [`hostedzones/service.justice.gov.uk.yaml`](diffhunk://#diff-519ec119fc6b4505bb004d2e256c4fcf9519220ff07062399bdee024e143a736R453-R460): Added a new DNS configuration under `change-dns` with a TTL of 300 and specified new nameserver values.