### PR TITLE
Update CICA records

### DIFF
--- a/hostedzones/cica.gov.uk.yaml
+++ b/hostedzones/cica.gov.uk.yaml
@@ -69,6 +69,9 @@ enterpriseenrollment:
 enterpriseregistration:
   type: CNAME
   value: enterpriseregistration.windows.net.
+mitrefinch:
+  type: CNAME
+  value: mitrefinch-cicagov.msappproxy.net.
 mta-sts:
   ttl: 942942942
   type: Route53Provider/ALIAS


### PR DESCRIPTION
This PR updates cica.gov.uk hosted zone with a new CNAME:

Name: mitrefinch
Type: CNAME
Value: mitrefinch-cicagov.msappproxy.net