### PR TITLE
Remove jo-staging.elinks.judiciary.uk

### DIFF
--- a/hostedzones/judiciary.uk.yaml
+++ b/hostedzones/judiciary.uk.yaml
@@ -284,9 +284,6 @@ jcm:
     - ns2-02.azure-dns.net.
     - ns3-02.azure-dns.org.
     - ns4-02.azure-dns.info.
-jo-staging.elinks:
-  type: CNAME
-  value: fathomless-plum-tu2fu458lxj0kj67y8yebcx9.herokudns.com
 judicialcareers:
   - ttl: 300
     type: A


### PR DESCRIPTION
## 👀 Purpose

- This PR removes a record for decommissioned service

## ♻️ What's changed

- Deletes `jo-staging.elinks.judiciary.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/IydZVKj516Y/m/czgN2Fe1BQAJ)