### PR TITLE
✨ Add GitHub Pages YAML Anchor & Refactor Runbooks Record

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -1,4 +1,4 @@
-github_pages_record: &github_pages_record
+github_pages_comment: &github_pages_comment
   comment: >
     # GitHub Pages delegation for ministryofjustice
     # This record points to ministryofjustice.github.io and is managed as a GitHub Pages resource.

--- a/common.yaml
+++ b/common.yaml
@@ -1,4 +1,17 @@
-github_pages_comment: &github_pages_comment
-  comment: >
+---
+variables:
+  github_pages_comment: &github_pages_comment >
     # GitHub Pages delegation for ministryofjustice
     # This record points to ministryofjustice.github.io and is managed as a GitHub Pages resource.
+
+  github_pages_ttl: &github_pages_ttl
+    ttl: 300
+
+  apex_a_record: &apex_a_record
+    type: A
+    ttl: *github_pages_ttl
+    value:
+      - 185.199.108.153
+      - 185.199.109.153
+      - 185.199.110.153
+      - 185.199.111.153

--- a/common.yaml
+++ b/common.yaml
@@ -1,0 +1,7 @@
+github_pages_record: &github_pages_record
+  ttl: 300
+  type: CNAME
+  value: ministryofjustice.github.io
+  comment: >
+    # GitHub Pages delegation for ministryofjustice
+    # This record points to ministryofjustice.github.io and is managed as a GitHub Pages resource.

--- a/common.yaml
+++ b/common.yaml
@@ -1,7 +1,4 @@
 github_pages_record: &github_pages_record
-  ttl: 300
-  type: CNAME
-  value: ministryofjustice.github.io
   comment: >
     # GitHub Pages delegation for ministryofjustice
     # This record points to ministryofjustice.github.io and is managed as a GitHub Pages resource.

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -798,13 +798,6 @@ ftp-hmcts.intranet:
   ttl: 300
   type: A
   value: 54.72.29.113
-github_pages_record: &github_pages_record
-  ttl: 300
-  type: CNAME
-  value: ministryofjustice.github.io
-  comment: >
-    # GitHub Pages delegation for ministryofjustice
-    # This record points to ministryofjustice.github.io and is managed as a GitHub Pages resource.
 gender-recognition:
   ttl: 300
   type: NS
@@ -813,6 +806,13 @@ gender-recognition:
     - ns-1726.awsdns-23.co.uk.
     - ns-371.awsdns-46.com.
     - ns-755.awsdns-30.net.
+github_pages_record: &github_pages_record
+  comment: >
+    # GitHub Pages delegation for ministryofjustice
+    # This record points to ministryofjustice.github.io and is managed as a GitHub Pages resource.
+  ttl: 300
+  type: CNAME
+  value: ministryofjustice.github.io
 haletest1:
   ttl: 300
   type: NS

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1,5 +1,4 @@
 ---
-<<: *common.github_pages_record
 "":
   - ttl: 1800
     type: MX

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1475,7 +1475,7 @@ runbooks.operations-engineering:
   ttl: 300
   type: CNAME
   value: ministryofjustice.github.io
-  <<: *github_pages_comment
+  comment: *github_pages_comment
 s1._domainkey.jac.intranet:
   ttl: 300
   type: CNAME

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1478,8 +1478,7 @@ review-criminal-legal-aid:
     - ns-1936.awsdns-50.co.uk.
     - ns-295.awsdns-36.com.
     - ns-604.awsdns-11.net.
-runbooks.operations-engineering:
-  <<: *github_pages_record
+runbooks.operations-engineering: *github_pages_record
 s1._domainkey.jac.intranet:
   ttl: 300
   type: CNAME

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1,5 +1,4 @@
 ---
-<<: *common.github_pages_record
 "":
   - ttl: 1800
     type: MX
@@ -799,6 +798,13 @@ ftp-hmcts.intranet:
   ttl: 300
   type: A
   value: 54.72.29.113
+github_pages_record: &github_pages_record
+  ttl: 300
+  type: CNAME
+  value: ministryofjustice.github.io
+  comment: >
+    # GitHub Pages delegation for ministryofjustice
+    # This record points to ministryofjustice.github.io and is managed as a GitHub Pages resource.
 gender-recognition:
   ttl: 300
   type: NS

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1478,7 +1478,9 @@ review-criminal-legal-aid:
     - ns-1936.awsdns-50.co.uk.
     - ns-295.awsdns-36.com.
     - ns-604.awsdns-11.net.
-runbooks.operations-engineering: *github_pages_record
+runbooks.operations-engineering:
+  <<: *github_pages_record
+  value: ministryofjustice.github.io
 s1._domainkey.jac.intranet:
   ttl: 300
   type: CNAME

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1,4 +1,5 @@
 ---
+<<: *common.github_pages_record
 "":
   - ttl: 1800
     type: MX
@@ -1472,9 +1473,7 @@ review-criminal-legal-aid:
     - ns-295.awsdns-36.com.
     - ns-604.awsdns-11.net.
 runbooks.operations-engineering:
-  ttl: 300
-  type: CNAME
-  value: ministryofjustice.github.io
+  <<: *github_pages_record
 s1._domainkey.jac.intranet:
   ttl: 300
   type: CNAME

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1,4 +1,5 @@
 ---
+<<: *common.github_pages_record
 "":
   - ttl: 1800
     type: MX
@@ -806,13 +807,6 @@ gender-recognition:
     - ns-1726.awsdns-23.co.uk.
     - ns-371.awsdns-46.com.
     - ns-755.awsdns-30.net.
-github_pages_record: &github_pages_record
-  comment: >
-    # GitHub Pages delegation for ministryofjustice
-    # This record points to ministryofjustice.github.io and is managed as a GitHub Pages resource.
-  ttl: 300
-  type: CNAME
-  value: ministryofjustice.github.io
 haletest1:
   ttl: 300
   type: NS
@@ -1479,8 +1473,10 @@ review-criminal-legal-aid:
     - ns-295.awsdns-36.com.
     - ns-604.awsdns-11.net.
 runbooks.operations-engineering:
-  <<: *github_pages_record
+  ttl: 300
+  type: CNAME
   value: ministryofjustice.github.io
+  <<: *github_pages_comment
 s1._domainkey.jac.intranet:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/operations-engineering/issues/4782

This pull request includes updates to DNS records in the `common.yaml` and `hostedzones/service.justice.gov.uk.yaml` files to standardise the GitHub Pages configuration and simplify the management of DNS records. The most important changes include the addition of a reusable GitHub Pages record and its application in different sections of the hosted zones configuration.

Standardization and simplification of DNS records:

* [`common.yaml`](diffhunk://#diff-20b4b6908742b7029e7ed3ac70d6db47f9b9420aaf337aee712da093d1f8d129R1-R7): Added a reusable GitHub Pages DNS record template with a TTL of 300, type CNAME, and value pointing to `ministryofjustice.github.io`.
* [`hostedzones/service.justice.gov.uk.yaml`](diffhunk://#diff-519ec119fc6b4505bb004d2e256c4fcf9519220ff07062399bdee024e143a736R2): Applied the reusable GitHub Pages DNS record template to the root domain configuration.
* [`hostedzones/service.justice.gov.uk.yaml`](diffhunk://#diff-519ec119fc6b4505bb004d2e256c4fcf9519220ff07062399bdee024e143a736L1475-R1476): Replaced the existing GitHub Pages DNS record for `runbooks.operations-engineering` with the reusable template.