### PR TITLE
🔧 Fix Workflow Failures by Updating `Makefile` to Use Correct Script Path

### DIFF
--- a/.github/workflows/check-change-status.yaml
+++ b/.github/workflows/check-change-status.yaml
@@ -6,7 +6,6 @@ on:
     types: [completed]
     branches: [main]
 
-
 jobs:
   check-change-status:
     runs-on: ubuntu-latest
@@ -14,15 +13,15 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: 3.11
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           role-to-assume: ${{ secrets.DNS_CHECK_CHANGE_STATUS_AWS_ROLE_ARN }}
           aws-region: us-east-1
@@ -36,7 +35,7 @@ jobs:
         uses: tj-actions/changed-files@40853de9f8ce2d6cfdc73c1b96f14e22ba44aec4 # v45.0.0
         with:
           files: |
-           hostedzones/**
+            hostedzones/**
 
       - name: Set hosted zone changed files environment variable
         env:

--- a/.github/workflows/check-empty-zones.yaml
+++ b/.github/workflows/check-empty-zones.yaml
@@ -25,8 +25,3 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.OCTODNS_AWS_SECRET_ACCESS_KEY }}
           PYTHONUNBUFFERED: 1
         run: make check-empty-zones
-
-      - name: Display results
-        run: |
-          echo "${{ steps.check-zones.outputs.result }}"
-          exit ${{ steps.check-zones.outputs.exit_code }}

--- a/.github/workflows/check-empty-zones.yaml
+++ b/.github/workflows/check-empty-zones.yaml
@@ -7,10 +7,10 @@ jobs:
   check-for-empty-zones:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: 3.11
 

--- a/.github/workflows/check-incorrect-action-pinning.yaml
+++ b/.github/workflows/check-incorrect-action-pinning.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Check for unpinned Actions
-        uses: ministryofjustice/github-actions/check-version-pinning@ccf9e3a4a828df1ec741f6c8e6ed9d0acaef3490
+        uses: ministryofjustice/github-actions/check-version-pinning@ccf9e3a4a828df1ec741f6c8e6ed9d0acaef3490 # v18.5.0
         with:
           workflow_directory: ".github/workflows"
           scan_mode: "full"

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -20,7 +20,7 @@ jobs:
           severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@f779452ac5af1c261dce0346a8f964149f49322b # v3.26.13
         with:
           sarif_file: "trivy-results.sarif"
 

--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,11 @@ compare-zone:
 
 check-unmanaged-zones: install
 	$(call check_aws_creds)
-	@pipenv run python3 check_unmanaged_zones.py
+	@pipenv run python3 -m  bin.check_unmanaged_zones
 
 check-empty-zones: install
 	$(call check_aws_creds)
-	@pipenv run python3 check_empty_zones.py
+	@pipenv run python3 -m bin.check_empty_zones
 
 clean:
 	@pipenv --rm


### PR DESCRIPTION
## 👀 Purpose

- In relation to this [Slack Alert](https://mojdt.slack.com/archives/C033QBE511V/p1730765865108779) - where workflow fails due to not being able to find the file
- Fixes https://github.com/ministryofjustice/dns/pull/256

## ♻️ What's changed

- Updates paths in the Makefile to use the new directory structure
- Pinned all GitHub Actions Versions
- Removed the `Display Results` step from the `Print Empty Zones` workflow - the script already does this and then step made ShellCheck complain 