### PR TITLE
Convert rpts.gov.uk to a defensive domain

### DIFF
--- a/hostedzones/rpts.gov.uk.yaml
+++ b/hostedzones/rpts.gov.uk.yaml
@@ -24,14 +24,14 @@
   - ttl: 300
     type: TXT
     value: v=spf1 -all
-_asvdns-168b3b39-52b4-4c50-bfe8-8622048b99a3:
-  ttl: 300
-  type: TXT
-  value: asvdns_ea1f3963-d40c-4b82-945e-24666ef10300
 '*._domainkey':
   ttl: 300
   type: TXT
   value: v=DKIM1\; p=
+_asvdns-168b3b39-52b4-4c50-bfe8-8622048b99a3:
+  ttl: 300
+  type: TXT
+  value: asvdns_ea1f3963-d40c-4b82-945e-24666ef10300
 _dmarc:
   ttl: 300
   type: TXT


### PR DESCRIPTION
## 👀 Purpose

- This domain is no longer is use but needs to be retained for defensive purposes. This PR updates DNS records to defensive standards.

## ♻️ What's changed

- Removes ARecord `rpts.gov.uk`
- Removes TXT Record `_smtp._tls.rpts.gov.uk`
- Removes ARecord `dev.rpts.gov.uk`
- Removes ARecord `test.rpts.gov.uk`
- Removes ARecord `uat.rpts.gov.uk`
- Updates MX Record `rpts.gov.uk`
- Updates TXT Record `rpts.gov.uk`
- Updates TXT Records `_dmarc.rpts.gov.uk`
- Adds CAA Record `rpts.gov.uk`
- Adds TXT Record `'*._domainkey'.rpts.gov.uk`
