### PR TITLE
Add CNAME jobs.justice.gov.uk

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -1099,13 +1099,16 @@ jira.cjscp:
   type: CNAME
   value: triadmoj.atlassian.net.
 jobs:
-  ttl: 10800
-  type: NS
-  values:
-    - ns-1332.awsdns-38.org
-    - ns-1916.awsdns-47.co.uk
-    - ns-531.awsdns-02.net
-    - ns-98.awsdns-12.com
+  - ttl: 300
+    type: CNAME
+    value: portals-justicejobs.avature.net
+  - ttl: 10800
+    type: NS
+    values:
+      - ns-1332.awsdns-38.org
+      - ns-1916.awsdns-47.co.uk
+      - ns-531.awsdns-02.net
+      - ns-98.awsdns-12.com
 join.meet.video:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR adds a CNAME value for `jobs.justice.gov.uk`. This CNAME will not work until the delegation to Cloud Platform is removed. This is pre-work for the migration scheduled for 18th November. This PR replicates the DKIM record that will allow email to be used with the new service.

## ♻️ What's changed

- Add CNAME record `jobs.justice.gov.uk`