### PR TITLE
Remove CNAME jobs.justice.gov.uk

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -1099,16 +1099,13 @@ jira.cjscp:
   type: CNAME
   value: triadmoj.atlassian.net.
 jobs:
-  - ttl: 300
-    type: CNAME
-    value: portals-justicejobs.avature.net
-  - ttl: 10800
-    type: NS
-    values:
-      - ns-1332.awsdns-38.org
-      - ns-1916.awsdns-47.co.uk
-      - ns-531.awsdns-02.net
-      - ns-98.awsdns-12.com
+  ttl: 10800
+  type: NS
+  values:
+    - ns-1332.awsdns-38.org
+    - ns-1916.awsdns-47.co.uk
+    - ns-531.awsdns-02.net
+    - ns-98.awsdns-12.com
 join.meet.video:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
This PR removes the CNAME jobs.justice.gov.uk to fix sync error. The CNAME and NS Record can't coexist so results in a failure.