### PR TITLE
♻️ GitHub Delegations: Use Makefile command + Add Documentation

### DIFF
--- a/.github/workflows/check-github-pages-records.yaml
+++ b/.github/workflows/check-github-pages-records.yaml
@@ -30,9 +30,9 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           if git diff --exit-code .github_pages; then
-            echo "no_changes=true" >> $GITHUB_ENV
+            echo "no_changes=true" >> "$GITHUB_ENV"
           else
-            echo "no_changes=false" >> $GITHUB_ENV
+            echo "no_changes=false" >> "$GITHUB_ENV"
           fi
 
       - name: Create Pull Request

--- a/.github/workflows/check-github-pages-records.yaml
+++ b/.github/workflows/check-github-pages-records.yaml
@@ -22,7 +22,7 @@ jobs:
         run: make install
 
       - name: Run the GitHub Pages script
-        run: pipenv run python -m bin.identify_github_pages_delegations
+        run: make print-github-delegations
 
       - name: Check for changes
         id: check_changes

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ help:
 	@echo "  make help                     - Show this help message"
 	@echo "  make install                  - Set up the Python environment"
 	@echo "  make list-zones               - List all zones"
-	@echo "  make print_github_delegation  - Identify GitHub Pages delegations and print the results"
+	@echo "  make print-github-delegations - Identify GitHub Pages delegations and print the results"
 	@echo "  make sync-apply               - Apply changes to all zones"
 	@echo "  make sync-dry-run             - Perform a dry-run sync for all zones"
 	@echo "  make test                     - Run the test suite"
@@ -101,7 +101,7 @@ clean:
 test: install
 	@pipenv run python3 -m pytest tests/
 
-print_github_delegation: install
+print-github-delegations:
 	@echo "Identifying GitHub Pages delegations..."
 	@pipenv run python3 -m bin.identify_github_pages_delegations
 	@echo "The file './.github_pages' has been updated with the latest GitHub Pages delegations."

--- a/Makefile
+++ b/Makefile
@@ -100,5 +100,10 @@ clean:
 test: install
 	@pipenv run python3 -m pytest tests/
 
+print_github_delegation: install
+	@echo "Identifying GitHub Pages delegations..."
+	@pipenv run python3 -m bin.identify_github_pages_delegations
+	@echo "The file './.github_pages' has been updated with the latest GitHub Pages delegations."
+
 .DEFAULT_GOAL := help
 

--- a/Makefile
+++ b/Makefile
@@ -18,18 +18,19 @@ endef
 
 help:
 	@echo "Available commands:"
-	@echo "  make check-empty-zones    - Run check for empty zones"
-	@echo "  make clean                - Clean up generated files"
+	@echo "  make check-empty-zones        - Run check for empty zones"
+	@echo "  make clean                    - Clean up generated files"
 	@echo "  make compare-zone zone=<zone> - Compare a zone file with its live configuration"
-	@echo "  make dump-zone zone=<zone> - Dump the current live configuration for a zone"
-	@echo "  make edit-zone zone=<zone> - Edit a hosted zone file"
-	@echo "  make help                 - Show this help message"
-	@echo "  make install              - Set up the Python environment"
-	@echo "  make list-zones           - List all zones"
-	@echo "  make sync-apply           - Apply changes to all zones"
-	@echo "  make sync-dry-run         - Perform a dry-run sync for all zones"
-	@echo "  make test                 - Run the test suite"
-	@echo "  make validate-zones       - Validate all zone files"
+	@echo "  make dump-zone zone=<zone>    - Dump the current live configuration for a zone"
+	@echo "  make edit-zone zone=<zone>    - Edit a hosted zone file"
+	@echo "  make help                     - Show this help message"
+	@echo "  make install                  - Set up the Python environment"
+	@echo "  make list-zones               - List all zones"
+	@echo "  make print_github_delegation  - Identify GitHub Pages delegations and print the results"
+	@echo "  make sync-apply               - Apply changes to all zones"
+	@echo "  make sync-dry-run             - Perform a dry-run sync for all zones"
+	@echo "  make test                     - Run the test suite"
+	@echo "  make validate-zones           - Validate all zone files"
 
 install:
 	pip3 install pipenv

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ print-github-delegations:
 	@echo "Identifying GitHub Pages delegations..."
 	@pipenv run python3 -m bin.identify_github_pages_delegations
 	@echo "The file './.github_pages' has been updated with the latest GitHub Pages delegations."
+	@cat .github_pages
 
 .DEFAULT_GOAL := help
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository manages the Ministry of Justice DNS records using [octoDNS](http
 ├── bin/                    # Contains various scripts to operate this repository
 ├── hostedzones/            # DNS zone files
 ├── .gitignore
-├── .github-pages           #  Domains and subdomains that are delegated to GitHub Pages
+├── .github_pages           #  Domains and subdomains that are delegated to GitHub Pages
 ├── LICENSE
 ├── Makefile
 ├── README.md

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ If you need to update the GitHub Pages records manually:
 
 1. Run the following command to identify changes:
 ```bash
-make print_github_delegation
+make print-github-delegations
 ```
 
 2. Commit and push any changes to the .github_pages file:

--- a/README.md
+++ b/README.md
@@ -4,13 +4,32 @@
 
 This repository manages the Ministry of Justice DNS records using [octoDNS](https://github.com/octodns/octodns). It provides a streamlined, code-based approach to DNS management, ensuring consistency and enabling version control for our DNS records.
 
+## 📖 Table of Contents
+
+1. [Repository Structure](#repository-structure)
+2. [How It Works](#how-it-works)
+3. [Configuration](#configuration)
+4. [CI/CD Pipeline](#cicd-pipeline)
+   - [AWS IAM User](#cicd-aws-iam-user)
+   - [AWS Credentials](#aws-credentials)
+5. [Making Changes](#making-changes)
+6. [Viewing Current Configuration](#viewing-current-configuration)
+7. [Applying Changes](#applying-changes)
+8. [GitHub Pages Management](#github-pages-management)
+   - [Weekly Automation](#weekly-automation)
+   - [Manual Identification](#manual-identification)
+9. [Makefile Commands](#makefile-commands)
+10. [License](#license)
+
 ## Repository Structure
 
 ```
 .
 ├── .github/                # GitHub Actions workflows
+├── bin/                    # Contains various scripts to operate this repository
 ├── hostedzones/            # DNS zone files
 ├── .gitignore
+├── .github-pages           #  Domains and subdomains that are delegated to GitHub Pages
 ├── LICENSE
 ├── Makefile
 ├── README.md
@@ -72,7 +91,7 @@ Ensure your AWS credentials have the necessary permissions to manage Route53 hos
 
 1. Clone this repository:
    ```bash
-   git clone https://github.com/your-org/dns.git
+   git clone https://github.com/ministryofjustice/dns.git
    cd dns
    ```
 
@@ -169,17 +188,18 @@ This will apply all pending changes to Route53. Always perform a `make sync-dry-
 This repository includes a Makefile to simplify common operations. You can use the following commands:
 
 ```bash
-make                    # Show help message with available commands
-make help               # Same as above, shows help message
-make install            # Set up the Python environment
-make edit-zone zone=<zone> # Edit a hosted zone file
-make validate-zones     # Validate all zone files
-make sync-dry-run       # Perform a dry-run sync for all zones
-make sync-apply         # Apply changes to all zones
-make list-zones         # List all zones
-make dump-zone zone=<zone> # Dump the current live configuration for a zone
+make                          # Show help message with available commands
+make help                     # Same as above, shows help message
+make install                  # Set up the Python environment
+make edit-zone zone=<zone>    # Edit a hosted zone file
+make validate-zones           # Validate all zone files
+make sync-dry-run             # Perform a dry-run sync for all zones
+make sync-apply               # Apply changes to all zones
+make list-zones               # List all zones
+make dump-zone zone=<zone>    # Dump the current live configuration for a zone
 make compare-zone zone=<zone> # Compare a zone file with its live configuration
-make clean              # Clean up generated files
+make clean                    # Clean up generated files
+make print-github-delegations # Print GitHub Pages delegations
 ```
 
 To see a full list of available commands and their descriptions, simply run `make` or `make help`.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,48 @@ make clean              # Clean up generated files
 
 To see a full list of available commands and their descriptions, simply run `make` or `make help`.
 
+## Identifying GitHub Pages Delegations
+
+This repository includes functionality to identify DNS records associated with GitHub Pages. These delegations are automatically identified and logged, and a Pull Request is created weekly if changes are detected.
+
+### Weekly Automation
+
+A GitHub Action runs every Sunday at midnight (UTC) to identify GitHub Pages delegations across the DNS records. If any changes are detected in the delegations, a Pull Request is automatically created with the updated `.github_pages` file. This file lists all GitHub Pages delegations in the format `<record>.<hostedzone>`.
+
+### Manual Identification
+
+To manually identify GitHub Pages delegations, you can use the following Makefile command:
+```bash
+make print_github_delegation
+```
+This command outputs the current list of GitHub Pages delegations in the .github_pages file.
+
+### Example .github_pages Output
+
+The .github_pages file contains entries in the format <record>.<hostedzone>. For example:
+
+```
+cjsm.justice.gov.uk
+hmpps-architecture-blueprint.service.justice.gov.uk
+runbooks.operations-engineering.service.justice.gov.uk
+```
+
+### Updating the GitHub Pages Records
+
+If you need to update the GitHub Pages records manually:
+
+1. Run the following command to identify changes:
+```bash
+make print_github_delegation
+```
+
+2. Commit and push any changes to the .github_pages file:
+```bash
+git add .github_pages
+git commit -m "Update GitHub Pages delegations"
+git push
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository manages the Ministry of Justice DNS records using [octoDNS](http
 
 ## Repository Structure
 
-```
+```bash
 .
 ├── .github/                # GitHub Actions workflows
 ├── bin/                    # Contains various scripts to operate this repository


### PR DESCRIPTION
This pull request introduces a new Makefile command to identify and print GitHub Pages delegations, updates the GitHub Actions workflow to use this command, and adds documentation on how to use it.

Key changes include:

### Makefile Updates:
* Added `print-github-delegations` command to identify and print GitHub Pages delegations.
* Updated the help section to include the new command.

### GitHub Actions Workflow:
* Modified the GitHub Pages script step to use the new Makefile command.

### Documentation:
* Added a section in `README.md` detailing how to identify GitHub Pages delegations, both manually and through the weekly automation.