### PR TITLE
Replace jobs.justice.gov.uk delegation with CNAME

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -1099,13 +1099,9 @@ jira.cjscp:
   type: CNAME
   value: triadmoj.atlassian.net.
 jobs:
-  ttl: 10800
-  type: NS
-  values:
-    - ns-1332.awsdns-38.org
-    - ns-1916.awsdns-47.co.uk
-    - ns-531.awsdns-02.net
-    - ns-98.awsdns-12.com
+  ttl: 300
+  type: CNAME
+  value: portals-justicejobs.avature.net
 join.meet.video:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR removes the existing delegation for `jobs.justice.gov.uk` and replaces it with a new CNAME. This in support of the migration to a new service.

## ♻️ What's changed

- Remove NS Record `jobs.justice.gov.uk`
- Add CNAME `jobs.justice.gov.uk`

## 📝 Notes

**Do not merge until 8:00 on Monday 18th November**