### PR TITLE
Remove dangling MX records for hmprisonservice.gov.uk

### DIFF
--- a/hostedzones/hmprisonservice.gov.uk.yaml
+++ b/hostedzones/hmprisonservice.gov.uk.yaml
@@ -1,14 +1,5 @@
 ---
 '':
-  - ttl: 600
-    type: MX
-    values:
-      - exchange: mailserv0.instant-web.co.uk.
-        preference: 10
-      - exchange: mailserv2.instant-web.co.uk.
-        preference: 20
-      - exchange: mailserv3.instant-web.co.uk.
-        preference: 20
   - ttl: 172800
     type: NS
     values:


### PR DESCRIPTION
## 👀 Purpose

- The PR removes dangling MX records that are no longer in use.

## ♻️ What's changed

- Remove MX record `hmprisonservice.gov.uk`

## 📝 Notes

- [Alert](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/JAjht5_ixQA/m/K9kUcdjsBgAJ)