### PR TITLE
♻️ Improve Readability & Efficiency Identifying GitHub Pages

### DIFF
--- a/bin/identify_github_pages_delegations.py
+++ b/bin/identify_github_pages_delegations.py
@@ -70,10 +70,10 @@ def process_record_generator(hostedzone, record_name, record):
         ip in record_values for ip in GITHUB_PAGES_AAAA_IPS
     ):
         yield format_output(record_name, hostedzone)
-    elif record_type in ["ALIAS", "ANAME"] and record_value in [
-        "USERNAME.github.io",
-        "ORGANIZATION.github.io",
-    ]:
+    elif (
+        record_type in ["ALIAS", "ANAME"]
+        and record_value == "ministryofjustice.github.io"
+    ):
         yield format_output(record_name, hostedzone)
 
 

--- a/tests/test_identify_github_pages_delegations.py
+++ b/tests/test_identify_github_pages_delegations.py
@@ -49,14 +49,14 @@ class TestGithubPagesFunctions(unittest.TestCase):
     def test_process_record_generator_alias(self):
         hostedzone = "service.justice.gov.uk"
         record_name = "aliasrecord"
-        record = {"type": "ALIAS", "value": "USERNAME.github.io"}
+        record = {"type": "ALIAS", "value": "ministryofjustice.github.io"}
         results = list(process_record_generator(hostedzone, record_name, record))
         self.assertIn("aliasrecord.service.justice.gov.uk", results)
 
     def test_process_hostedzone_records(self):
         hostedzone = "service.justice.gov.uk"
         records = {
-            "www": {"type": "CNAME", "value": "username.github.io"},
+            "www": {"type": "CNAME", "value": "ministryofjustice.github.io"},
             "example": {"type": "A", "values": ["185.199.108.153"]},
         }
         results = list(process_hostedzone_records(hostedzone, records))

--- a/tests/test_identify_github_pages_delegations.py
+++ b/tests/test_identify_github_pages_delegations.py
@@ -1,10 +1,15 @@
 import unittest
+from unittest.mock import patch
 
-from bin.identify_github_pages_delegations import format_output, process_record
+from bin.identify_github_pages_delegations import (
+    find_github_pages_records,
+    format_output,
+    process_hostedzone_records,
+    process_record_generator,
+)
 
 
 class TestGithubPagesFunctions(unittest.TestCase):
-
     def test_format_output_with_record(self):
         result = format_output("www", "service.justice.gov.uk")
         self.assertEqual(result, "www.service.justice.gov.uk")
@@ -13,45 +18,56 @@ class TestGithubPagesFunctions(unittest.TestCase):
         result = format_output("", "service.justice.gov.uk")
         self.assertEqual(result, "service.justice.gov.uk")
 
-    def test_process_record_cname(self):
-        records = []
+    def test_process_record_generator_cname(self):
         hostedzone = "service.justice.gov.uk"
         record_name = "www"
         record = {"type": "CNAME", "value": "username.github.io"}
-        process_record(records, hostedzone, record_name, record)
-        self.assertIn("www.service.justice.gov.uk", records)
+        results = list(process_record_generator(hostedzone, record_name, record))
+        self.assertIn("www.service.justice.gov.uk", results)
 
-    def test_process_record_a(self):
-        records = []
+    def test_process_record_generator_a(self):
         hostedzone = "service.justice.gov.uk"
         record_name = "example"
         record = {"type": "A", "values": ["185.199.108.153"]}
-        process_record(records, hostedzone, record_name, record)
-        self.assertIn("example.service.justice.gov.uk", records)
+        results = list(process_record_generator(hostedzone, record_name, record))
+        self.assertIn("example.service.justice.gov.uk", results)
 
-    def test_process_record_a_no_match(self):
-        records = []
+    def test_process_record_generator_a_no_match(self):
         hostedzone = "service.justice.gov.uk"
         record_name = "example"
         record = {"type": "A", "values": ["192.0.2.1"]}  # Not a GitHub Pages IP
-        process_record(records, hostedzone, record_name, record)
-        self.assertNotIn("example.service.justice.gov.uk", records)
+        results = list(process_record_generator(hostedzone, record_name, record))
+        self.assertNotIn("example.service.justice.gov.uk", results)
 
-    def test_process_record_aaaa(self):
-        records = []
+    def test_process_record_generator_aaaa(self):
         hostedzone = "service.justice.gov.uk"
         record_name = "example"
         record = {"type": "AAAA", "values": ["2606:50c0:8000::153"]}
-        process_record(records, hostedzone, record_name, record)
-        self.assertIn("example.service.justice.gov.uk", records)
+        results = list(process_record_generator(hostedzone, record_name, record))
+        self.assertIn("example.service.justice.gov.uk", results)
 
-    def test_process_record_alias(self):
-        records = []
+    def test_process_record_generator_alias(self):
         hostedzone = "service.justice.gov.uk"
         record_name = "aliasrecord"
         record = {"type": "ALIAS", "value": "USERNAME.github.io"}
-        process_record(records, hostedzone, record_name, record)
-        self.assertIn("aliasrecord.service.justice.gov.uk", records)
+        results = list(process_record_generator(hostedzone, record_name, record))
+        self.assertIn("aliasrecord.service.justice.gov.uk", results)
+
+    def test_process_hostedzone_records(self):
+        hostedzone = "service.justice.gov.uk"
+        records = {
+            "www": {"type": "CNAME", "value": "username.github.io"},
+            "example": {"type": "A", "values": ["185.199.108.153"]},
+        }
+        results = list(process_hostedzone_records(hostedzone, records))
+        self.assertIn("www.service.justice.gov.uk", results)
+        self.assertIn("example.service.justice.gov.uk", results)
+
+    @patch("os.scandir")
+    def test_find_github_pages_records_empty(self, mock_scandir):
+        mock_scandir.return_value = []
+        results = list(find_github_pages_records("mocked_directory"))
+        self.assertEqual(results, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 👀 Purpose

- This PR improves the readability & efficiency of the code used to Identify domains delegated to GitHub Pages.


## ♻️ What's changed

- It utilises the Python yield operator to reduce memory usage.
- Improves the logic for processing individual records.
- Handles YAML parsing errors.
- Refactors the tests to reflect the change in structure.

## 📝 Notes

This pull request includes several updates to the test suite for the `identify_github_pages_delegations` module. The changes primarily involve the addition of new tests and the refactoring of existing ones to use a generator function for processing records.

### Test Suite Enhancements:

* Added import for `patch` from `unittest.mock` to facilitate mocking in tests. (`tests/test_identify_github_pages_delegations.py`)
* Refactored existing tests to use `process_record_generator` instead of `process_record`, ensuring consistency and leveraging generator functionality. (`tests/test_identify_github_pages_delegations.py`)
* Added a new test `test_process_hostedzone_records` to verify the processing of multiple records within a hosted zone. (`tests/test_identify_github_pages_delegations.py`)
* Introduced `test_find_github_pages_records_empty` with a mock for `os.scandir` to test the behavior when no records are found. (`tests/test_identify_github_pages_delegations.py`)