### PR TITLE
Remove pki.digital.justice.gov.uk

### DIFF
--- a/hostedzones/digital.justice.gov.uk.yaml
+++ b/hostedzones/digital.justice.gov.uk.yaml
@@ -222,10 +222,6 @@ mta-sts:
     hosted-zone-id: Z2FDTNDATAQYW2
     name: dq5u7fyz5mukp.cloudfront.net.
     type: A
-pki:
-  ttl: 600
-  type: CNAME
-  value: pki.digital.justice.gov.uk.s3-website.eu-west-2.amazonaws.com
 proxy:
   ttl: 942942942
   type: Route53Provider/ALIAS


### PR DESCRIPTION
This PR removes `pki.digital.justice.gov.uk` to address security vulnerability. 