### PR TITLE
Add IMA CNAME

### DIFF
--- a/hostedzones/ima-citizensrights.org.uk.yaml
+++ b/hostedzones/ima-citizensrights.org.uk.yaml
@@ -87,6 +87,10 @@ _smtp._tls.newsletter:
   ttl: 300
   type: TXT
   value: v=TLSRPTv1\;rua=mailto:tls-rua@mailcheck.service.ncsc.gov.uk
+_w30aazpyu2wf1o7i44ctxvtquujbf3a.complaints:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 autodiscover:
   type: CNAME
   value: autodiscover.outlook.com


### PR DESCRIPTION
This PR adds the Gandi certificate verifcation CNAME for complaints.ima-citizensrights.org.uk