### PR TITLE
Replace job.justice.gov.uk delegation with CNAME

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -1104,12 +1104,8 @@ jira.cjscp:
   value: triadmoj.atlassian.net.
 jobs:
   ttl: 300
-  type: NS
-  values:
-    - ns-1332.awsdns-38.org
-    - ns-1916.awsdns-47.co.uk
-    - ns-531.awsdns-02.net
-    - ns-98.awsdns-12.com
+  type: CNAME
+  value: portals-justicejobs.avature.net
 join.meet.video:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR removes the existing delegation for `jobs.justice.gov.uk` and replaces it with a new CNAME. This in support of the migration to a new service. This change was rolled back and this is a second attemp.

## ♻️ What's changed

- Remove NS Record `jobs.justice.gov.uk`
- Add CNAME `jobs.justice.gov.uk`

## 📝 Notes

**Do not merge - implementation time  14:00 on 18th November 2024**