### PR TITLE
Revert job.justice.gov.uk CNAME change

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -1104,8 +1104,12 @@ jira.cjscp:
   value: triadmoj.atlassian.net.
 jobs:
   ttl: 300
-  type: CNAME
-  value: portals-justicejobs.avature.net
+  type: NS
+  values:
+    - ns-1332.awsdns-38.org
+    - ns-1916.awsdns-47.co.uk
+    - ns-531.awsdns-02.net
+    - ns-98.awsdns-12.com
 join.meet.video:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
Revert change to revert to pre-migration service