### PR TITLE
Update job.justice.gov.uk CNAME

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -1105,7 +1105,7 @@ jira.cjscp:
 jobs:
   ttl: 300
   type: CNAME
-  value: sandboxjusticejobs.avature.net
+  value: portals-justicejobs.avature.net
 join.meet.video:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
The PR changes to CNAME to point from sandbox to production environment