### PR TITLE
Delegate hmppsinsights.service.justice.gov.uk to Cloud Platform

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -899,9 +899,13 @@ hmpps-performance-hub:
   type: CNAME
   value: performance-hub.hmpps-production.modernisation-platform.service.justice.gov.uk
 hmppsinsights:
-  ttl: 300
-  type: A
-  value: 35.214.43.34
+  ttl: 86400
+  type: NS
+  values:
+    - ns-1435.awsdns-51.org
+    - ns-1554.awsdns-02.co.uk
+    - ns-665.awsdns-19.net
+    - ns-9.awsdns-01.com
 integrated-fraud-system:
   ttl: 86400
   type: NS

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1830,10 +1830,6 @@ www.dev.victim-case-management:
   ttl: 300
   type: CNAME
   value: www.dev.vcms.probation.hmpps.dsd.io
-www.hmppsinsights:
-  ttl: 300
-  type: CNAME
-  value: hmppsinsights.service.justice.gov.uk
 www.perf.victim-case-management:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- The PR delegates `hmppsinsights.service.justice.gov.uk` subdomain to Cloud Platform in support of new service.

## ♻️ What's changed

- Replace `hmppsinsights.service.justice.gov.uk` ARECORD with NS Records
- Remove CNAME `www.hmppsinsights.service.justice.gov.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/yjfcenwNM_E/m/FI4jJThZAQAJ)

**DO NOT MERGE UNTIL 12:00 on Monday 2nd December 2024**