### PR TITLE
Remove delegation studio-hosting.service.justice.gov.uk

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1642,14 +1642,6 @@ staging.signon:
   ttl: 300
   type: CNAME
   value: staging.signon.service.justice.gov.uk.herokudns.com
-studio-hosting:
-  ttl: 300
-  type: NS
-  values:
-    - ns1-07.azure-dns.com.
-    - ns2-07.azure-dns.net.
-    - ns3-07.azure-dns.org.
-    - ns4-07.azure-dns.info.
 suaehjnchl4x3uc37ltzv4sjvox32tsg._domainkey:
   ttl: 1800
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR removes the delegation for `studio-hosting.service.justice.gov.uk`. Services have been decommissioned.

## ♻️ What's changed

- Delete NS Record `studio-hosting.service.justice.gov.uk`

## 📝 Notes

- [Request](https://mojdt.slack.com/archives/C6D94J81E/p1733391001502919)