### PR TITLE
Changes in support of new Judicial College service

### DIFF
--- a/hostedzones/judiciary.gov.uk.yaml
+++ b/hostedzones/judiciary.gov.uk.yaml
@@ -46,10 +46,6 @@ _dmarc:
   ttl: 600
   type: CNAME
   value: _dmarc_ttp_policy.justice.gov.uk
-_dmarc.judicialcollege:
-  ttl: 300
-  type: CNAME
-  value: dmarc.mail.judicial.kineoedition.com
 _ecf9157f031ef82308cee8de3c342dbe.intranet:
   ttl: 600
   type: CNAME
@@ -66,6 +62,10 @@ civiljusticecouncil:
   ttl: 600
   type: A
   value: 80.86.35.81
+default._domainkey.judicialcollege:
+  ttl: 300
+  type: TXT
+  value: v=DKIM1; h=sha256; k=rsa;
 familyjusticecouncil:
   ttl: 600
   type: A
@@ -87,9 +87,12 @@ jars.jac:
   type: A
   value: 185.40.8.147
 judicialcollege:
-  ttl: 300
-  type: CNAME
-  value: judicial.kineoedition.com
+  - ttl: 300
+    type: CNAME
+    value: judicial.think-learning.com
+  - ttl: 300
+    type: TXT
+    value: v=spf1 mx a ip4:5.57.63.229 -all
 judicialconduct:
   ttl: 600
   type: NS
@@ -106,10 +109,6 @@ jwss:
     hosted-zone-id: Z3GKZC51ZF0DB4
     name: s3-website.eu-west-2.amazonaws.com.
     type: A
-kineolms._domainkey.judicialcollege:
-  ttl: 300
-  type: CNAME
-  value: dkim.mail.judicial.kineoedition.com
 search:
   ttl: 600
   type: A

--- a/hostedzones/judiciary.gov.uk.yaml
+++ b/hostedzones/judiciary.gov.uk.yaml
@@ -87,9 +87,12 @@ jars.jac:
   type: A
   value: 185.40.8.147
 judicialcollege:
-  ttl: 300
-  type: CNAME
-  value: judicial.think-learning.com
+  - ttl: 300
+    type: A
+    value: 5.57.63.145
+  - ttl: 300
+    type: TXT
+    value: v=spf1 mx a ip4:5.57.63.229 -all
 judicialconduct:
   ttl: 600
   type: NS

--- a/hostedzones/judiciary.gov.uk.yaml
+++ b/hostedzones/judiciary.gov.uk.yaml
@@ -87,12 +87,9 @@ jars.jac:
   type: A
   value: 185.40.8.147
 judicialcollege:
-  - ttl: 300
-    type: CNAME
-    value: judicial.think-learning.com
-  - ttl: 300
-    type: TXT
-    value: v=spf1 mx a ip4:5.57.63.229 -all
+  ttl: 300
+  type: CNAME
+  value: judicial.think-learning.com
 judicialconduct:
   ttl: 600
   type: NS


### PR DESCRIPTION
## 👀 Purpose

- The PR makes changes to `judicialcollege.judiciary.gov.uk` subdomains in support of migration to a new service.

## ♻️ What's changed

- Add A Record `judicialcollege.judiciary.gov.uk`
- Remove CNAME `judicialcollege.judiciary.gov.uk`
- Remove CNAME `_dmarc.judicialcollege.judiciary.gov.uk`
- Remove CNAME `kineolms._domainkey.judicialcollege.judiciary.gov.uk`
- Add TXT record `default._domainkey.judicialcollege.judiciary.gov.uk`
- Add TXT record `judicialcollege.judiciary.gov.uk`

## 📝 Notes

[Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/kP9266sCFi4/m/-Zt2G9NwAwAJ)

- **DO NOT MERGE BEFORE 16th DECEMBER 2024 - AWAITING GO/NO-GO DECISION**