### PR TITLE
Rollback Nginx Migration Changes

### DIFF
--- a/hostedzones/ahmlr.gov.uk.yaml
+++ b/hostedzones/ahmlr.gov.uk.yaml
@@ -7,12 +7,12 @@
       - ns-127.awsdns-15.com.
       - ns-1724.awsdns-23.co.uk.
       - ns-632.awsdns-15.net.
-  - ttl: 942942942
+   - ttl: 942942942
     type: Route53Provider/ALIAS
     value:
       evaluate-target-health: false
-      hosted-zone-id: ZHURV8PSTC4K8
-      name: tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com.
+      hosted-zone-id: Z32O12XQLNTSW2
+      name: tribunals-nginx-1184258455.eu-west-1.elb.amazonaws.com.
       type: A
 _asvdns-5fe0995c-f880-431b-a38b-4505e6dade0f:
   ttl: 300

--- a/hostedzones/ahmlr.gov.uk.yaml
+++ b/hostedzones/ahmlr.gov.uk.yaml
@@ -7,7 +7,7 @@
       - ns-127.awsdns-15.com.
       - ns-1724.awsdns-23.co.uk.
       - ns-632.awsdns-15.net.
-   - ttl: 942942942
+  - ttl: 942942942
     type: Route53Provider/ALIAS
     value:
       evaluate-target-health: false

--- a/hostedzones/carestandardstribunal.gov.uk.yaml
+++ b/hostedzones/carestandardstribunal.gov.uk.yaml
@@ -11,8 +11,8 @@
     type: Route53Provider/ALIAS
     value:
       evaluate-target-health: false
-      hosted-zone-id: ZHURV8PSTC4K8
-      name: tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com.
+      hosted-zone-id: Z32O12XQLNTSW2
+      name: tribunals-nginx-1184258455.eu-west-1.elb.amazonaws.com.
       type: A
 _asvdns-8d00d173-2054-4f62-a26c-ac866af546e1:
   ttl: 300

--- a/hostedzones/cicap.gov.uk.yaml
+++ b/hostedzones/cicap.gov.uk.yaml
@@ -16,8 +16,8 @@
     type: Route53Provider/ALIAS
     value:
       evaluate-target-health: false
-      hosted-zone-id: ZHURV8PSTC4K8
-      name: tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com.
+      hosted-zone-id: Z32O12XQLNTSW2
+      name: tribunals-nginx-1184258455.eu-west-1.elb.amazonaws.com.
       type: A
 _asvdns-03b6f09c-39de-49bb-ab61-98904b93aa95:
   ttl: 300

--- a/hostedzones/employmentappeals.gov.uk.yaml
+++ b/hostedzones/employmentappeals.gov.uk.yaml
@@ -11,8 +11,8 @@
     type: Route53Provider/ALIAS
     value:
       evaluate-target-health: false
-      hosted-zone-id: ZHURV8PSTC4K8
-      name: tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com.
+      hosted-zone-id: Z32O12XQLNTSW2
+      name: tribunals-nginx-1184258455.eu-west-1.elb.amazonaws.com.
       type: A
 _dmarc:
   ttl: 300

--- a/hostedzones/financeandtaxtribunals.gov.uk.yaml
+++ b/hostedzones/financeandtaxtribunals.gov.uk.yaml
@@ -16,8 +16,8 @@
     type: Route53Provider/ALIAS
     value:
       evaluate-target-health: false
-      hosted-zone-id: ZHURV8PSTC4K8
-      name: tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com.
+      hosted-zone-id: Z32O12XQLNTSW2
+      name: tribunals-nginx-1184258455.eu-west-1.elb.amazonaws.com.
       type: A
 _4416e320d11c5c898a5a17f5b96495f2.downloader:
   ttl: 300

--- a/hostedzones/immigrationservicestribunal.gov.uk.yaml
+++ b/hostedzones/immigrationservicestribunal.gov.uk.yaml
@@ -11,8 +11,8 @@
     type: Route53Provider/ALIAS
     value:
       evaluate-target-health: false
-      hosted-zone-id: ZHURV8PSTC4K8
-      name: tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com.
+      hosted-zone-id: Z32O12XQLNTSW2
+      name: tribunals-nginx-1184258455.eu-west-1.elb.amazonaws.com.
       type: A
 _dmarc:
   ttl: 300

--- a/hostedzones/informationtribunal.gov.uk.yaml
+++ b/hostedzones/informationtribunal.gov.uk.yaml
@@ -11,8 +11,8 @@
     type: Route53Provider/ALIAS
     value:
       evaluate-target-health: false
-      hosted-zone-id: ZHURV8PSTC4K8
-      name: tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com.
+      hosted-zone-id: Z32O12XQLNTSW2
+      name: tribunals-nginx-1184258455.eu-west-1.elb.amazonaws.com.
       type: A
 _dmarc:
   ttl: 300

--- a/hostedzones/osscsc.gov.uk.yaml
+++ b/hostedzones/osscsc.gov.uk.yaml
@@ -11,8 +11,8 @@
     type: Route53Provider/ALIAS
     value:
       evaluate-target-health: false
-      hosted-zone-id: ZHURV8PSTC4K8
-      name: tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com.
+      hosted-zone-id: Z32O12XQLNTSW2
+      name: tribunals-nginx-1184258455.eu-west-1.elb.amazonaws.com.
       type: A
 _dmarc:
   ttl: 300

--- a/hostedzones/transporttribunal.gov.uk.yaml
+++ b/hostedzones/transporttribunal.gov.uk.yaml
@@ -11,8 +11,8 @@
     type: Route53Provider/ALIAS
     value:
       evaluate-target-health: false
-      hosted-zone-id: ZHURV8PSTC4K8
-      name: tribunals-nginx-364120249.eu-west-2.elb.amazonaws.com.
+      hosted-zone-id: Z32O12XQLNTSW2
+      name: tribunals-nginx-1184258455.eu-west-1.elb.amazonaws.com.
       type: A
 _dmarc:
   ttl: 300


### PR DESCRIPTION
## 👀 Purpose

- Rollback of Nginx migration changes to allow for changes to related infrastructure to fix production incident

## ♻️ What's changed

- Update ARECORD `ahmlr.gov.uk`
- Update ARECORD `carestandardstribunal.gov.uk`
- Update ARECORD `cicap.gov.uk`
- Update ARECORD `employmentappeals.gov.uk`
- Update ARECORD `financeandtaxtribunals.gov.uk`
- Update ARECORD `immigrationservicestribunal.gov.uk`
- Update ARECORD `informationtribunal.gov.uk`
- Update ARECORD `osscsc.gov.uk`
- Update ARECORD `transporttribunal.gov.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/FiFXmFzPmns/m/X1HFrg-8BQAJ)