### PR TITLE
Add TXT record to cjsm.justice.gov.uk Hostedzone

### DIFF
--- a/hostedzones/cjsm.justice.gov.uk.yaml
+++ b/hostedzones/cjsm.justice.gov.uk.yaml
@@ -14,6 +14,10 @@
       - ns-1398.awsdns-46.org.
       - ns-1759.awsdns-27.co.uk.
       - ns-24.awsdns-03.com.
+_github-pages-challenge-ministryofjustice.cjsm:
+  ttl: 300
+  type: TXT
+  value: 5bd5cba430ba2c447f57895913e20b
 www:
   ttl: 300
   type: NS

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -222,10 +222,6 @@ _github-challenge-moj-analytical-services:
   ttl: 300
   type: TXT
   value: 610cab0fa8
-_github-pages-challenge-ministryofjustice.cjsm:
-  ttl: 300
-  type: TXT
-  value: 5bd5cba430ba2c447f57895913e20b
 _h323cs._tcp.meet.video:
   ttl: 300
   type: SRV


### PR DESCRIPTION
## 👀 Purpose

- The PR adds a GitHub TXT validation record record to verify domain ownership for `cjsm.justice.gov.uk`. This PR add the record to the correct Hostedzone.

## ♻️ What's changed

- Remove TXT record `_github-pages-challenge-ministryofjustice.cjsm.justice.gov.uk` from justice.gov.uk zone
- Add TXT record to `_github-pages-challenge-ministryofjustice.cjsm.justice.gov.uk` cjsm.justice.gov.uk zone
