### PR TITLE
Update production court.store.justice.gov.uk subdomains

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -594,8 +594,8 @@ cms-staging.court.store:
   value: 13.42.88.61
 cms.court.store:
   ttl: 300
-  type: A
-  value: 51.231.76.132
+  type: CNAME
+  value: hmcts-cs-prod-psn-nlb-cms-01-89d5e2c0f4ad83f2.elb.eu-west-2.amazonaws.com
 commissioning:
   ttl: 600
   type: A
@@ -1186,8 +1186,8 @@ libra-staging.court.store:
   value: 13.42.88.61
 libra.court.store:
   ttl: 300
-  type: A
-  value: 51.231.76.132
+  type: CNAME
+  value: hmcts-cs-prod-psn-nlb-libra-01-c3794588b8ade9a4.elb.eu-west-2.amazonaws.com
 lli5y5gi7j6oibymkdt3aeovvaumzmkc._domainkey.uat.ppud:
   ttl: 300
   type: CNAME
@@ -1757,8 +1757,8 @@ staff-staging.court.store:
   value: 18.168.187.252
 staff.court.store:
   ttl: 300
-  type: A
-  value: 51.231.76.135
+  type: CNAME
+  value: hmcts-cs-prod-psn-nlb-staff-01-06e4f7696903a278.elb.eu-west-2.amazonaws.com
 stage:
   ttl: 86400
   type: NS


### PR DESCRIPTION
## 👀 Purpose

- This PR replaces three production `court.store.justice.gov.uk` A RECORDS with CNAMES. This change is in support of migration to new applications.

## ♻️ What's changed

- Replace A RECORD `libra.court.store.justice.gov.uk` with CNAME `libra.court.store.justice.gov.uk`
- Replace A RECORD `cms.court.store.justice.gov.uk` with CNAME `cms.court.store.justice.gov.uk`
- Replace A RECORD `staff.court.store.justice.gov.uk` with CNAME `staff.court.store.justice.gov.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/DXae5CN-4bA/m/ShxGG_DiCQAJ)

- **DO NOT MERGE BEFORE 23:30 ON FRIDAY 17TH JANUARY**