### PR TITLE
Add certificate validation CNAMES

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -55,6 +55,10 @@
   ttl: 300
   type: TXT
   value: v=DKIM1\; p=
+_0B4B77F31E0F90E752FE16DA1810831A.staging.courtstore:
+  ttl: 300
+  type: CNAME
+  value: 8C40DCE2B4F6F83316089C32A15C0EA1.B3F1966F5B975B95B8D69F2E2FF3CB8B.fb926d8defb1bce310bb.sectigo.com.
 _1b792c2153cf927328615e78010f7852.civilmediation:
   ttl: 300
   type: CNAME
@@ -153,6 +157,10 @@ _c3e197db2fd6871349b94aaee4fe4c51.mta-sts.cshrcasework:
   ttl: 60
   type: CNAME
   value: _471469039df6a6e4e24c985c337b70a9.zrvsvrxrgs.acm-validations.aws.
+_C4634E68C639D7960A5F94E4472B7830.bench.staging.courtstore:
+  ttl: 300
+  type: CNAME
+  value: 25A41D198840FA674D7BC9C2AA371AFD.9B564615108D9FA3B84860275C3A46B9.fada458200750394a41.sectigo.com.
 _d97fb4f4ad2c4d0e83508935752915f1.ccmstraining:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
Add CNAMES to validate the following certificates:

 - [staging.courtstore.justice.gov.uk](http://0b4b77f31e0f90e752fe16da1810831a.staging.courtstore.justice.gov.uk/)
 - [bench.staging.courtstore.justice.gov.uk](http://c4634e68c639d7960a5f94e4472b7830.bench.staging.courtstore.justice.gov.uk/)