### PR TITLE
Reduce ttl to 300 for administrativecourtoffice.justice.gov.uk

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -466,7 +466,8 @@ administrativecourtoffice:
         preference: 10
       - exchange: cluster5a.eu.messagelabs.com
         preference: 20
-  - type: TXT
+  -ttl: 300
+    type: TXT
     values:
       - C0E4N61551
       - MS=ms89669471

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -466,7 +466,7 @@ administrativecourtoffice:
         preference: 10
       - exchange: cluster5a.eu.messagelabs.com
         preference: 20
-  -ttl: 300
+  - ttl: 300
     type: TXT
     values:
       - C0E4N61551


### PR DESCRIPTION
## 👀 Purpose

- The PR brings the TTL for TXT record `administrativecourtoffice.justice.gov.uk` to be managed in code. After a review of TTL pre-migration checks we found that the TTL for this record was not being managed.

## ♻️ What's changed

- Add TTL for `administrativecourtoffice.justice.gov.uk`