### PR TITLE
Add MTA-STS related DNS records for administrativecourtoffice

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -314,6 +314,10 @@ _mta-sts:
   ttl: 300
   type: TXT
   value: v=STSv1\; id=c34048034e0bdb6b6bc9b2d52699588c
+_mta-sts.administrativecourtoffice:
+  ttl: 300
+  type: TXT
+  value: v=STSv1; id=6635d30aeefe09475a70f59c9e98c6eb
 _mta-sts.cshrcasework:
   ttl: 300
   type: TXT
@@ -434,6 +438,10 @@ _smtp._tls:
   ttl: 300
   type: TXT
   value: v=TLSRPTv1\;rua=mailto:tls-rua@mailcheck.service.ncsc.gov.uk
+_smtp._tls.administrativecourtoffice:
+  ttl: 300
+  type: TXT
+  value: "v=TLSRPTv1;rua=mailto:tls-rua@mailcheck.service.ncsc.gov.uk"
 _smtp._tls.cjscp:
   ttl: 300
   type: TXT
@@ -1425,6 +1433,14 @@ mta-sts:
     evaluate-target-health: true
     hosted-zone-id: Z2FDTNDATAQYW2
     name: d10ub3a63bvlod.cloudfront.net.
+    type: A
+mta-sts.administrativecourtoffice:
+  ttl: 942942942
+  type: Route53Provider/ALIAS
+  value:
+    evaluate-target-health: true
+    hosted-zone-id: Z2BAIDDV5DBDJR
+    name: dyycavqzg4wxp.cloudfront.net.
     type: A
 mta-sts.cshrcasework:
   ttl: 942942942

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -71,6 +71,10 @@ _19c1935c338c1a473a54c55c3260a113.mta-sts:
   ttl: 60
   type: CNAME
   value: _deaf7cf7dd6d67b9f69b147486e6a1c9.pczglchxlc.acm-validations.aws.
+_956e7fb445bb521906e78cc188987061.mta-sts.administrativecourtoffice:
+  ttl: 60
+  type: CNAME
+  value: _10f4de44369caed5844b2065e39c2c4f.zfyfvmchrl.acm-validations.aws.
 _0970bea3431bc1236acaba02e9f46366.www.civilmediation:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR add MTA-STS related DNS records for `administrativecourtoffice.gov.uk`. This PR doesn't create these records as they have already been created by MTA-STS. This PR just ensures that the DNS records are captured in IAC.

## ♻️ What's changed

- Add TXT record `_mta-sts.administrativecourtoffice.justice.gov.uk`
- Add TXT record `_smtp._tls.administrativecourtoffice.justice.gov.uk`
- Add ALIAS record `mta-sts.administrativecourtoffice.justice.gov.uk`
- Add CNAME record `_956e7fb445bb521906e78cc188987061.mta-sts.administrativecourtoffice.justice.gov.uk`