### PR TITLE
Add Google Domain recovery TXT Record

### DIFF
--- a/hostedzones/public-guardian.co.uk.yaml
+++ b/hostedzones/public-guardian.co.uk.yaml
@@ -24,9 +24,6 @@
   - ttl: 3600
     type: TXT
     value: v=spf1 -all
-  - ttl: 300
-    type: TXT
-    value: google-gws-recovery-domain-verification=57195953
 '*._domainkey':
   ttl: 300
   type: TXT

--- a/hostedzones/public-guardian.co.uk.yaml
+++ b/hostedzones/public-guardian.co.uk.yaml
@@ -21,9 +21,12 @@
       - ns-1938.awsdns-50.co.uk.
       - ns-485.awsdns-60.com.
       - ns-700.awsdns-23.net.
-  - ttl: 300
+  - ttl: 3600
     type: TXT
     value: v=spf1 -all
+  - ttl: 300
+    type: TXT
+    value: google-gws-recovery-domain-verification=57195953
 '*._domainkey':
   ttl: 300
   type: TXT

--- a/hostedzones/publicguardian.gov.uk.yaml
+++ b/hostedzones/publicguardian.gov.uk.yaml
@@ -27,6 +27,9 @@
       - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32 include:spf.protection.outlook.com
         -all
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
+  - ttl: 300
+    type: TXT
+    value: google-gws-recovery-domain-verification=57195953
 _asvdns-8a5e9946-76d7-4e78-83b0-5f3be2e0e7b0:
   ttl: 300
   type: TXT


### PR DESCRIPTION
We are required to claim ownership of the publicguardian.gov.uk domain in our Google Account. This appears to be already registered and this TXT allows Google to verify we own it and add it to our account.

![image](https://github.com/user-attachments/assets/4acf85cb-4590-4a8d-8e52-ea2d8ea6357f)
