### PR TITLE
Add Ardoq email DNS records

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -24,7 +24,7 @@
       - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
       - paloaltonetworks-site-verification=0b174a69a0bbb0078f1b18f4bac05c0bd943f50b2e279ea920cfe4e085ec4a48
-      - v=spf1 ip4:194.33.196.0/24 ip4:194.33.192.0/24 mx a:b.spf.service-now.com a:c.spf.service-now.com a:d.spf.service-now.com include:spf.protection.outlook.com include:_spf.google.com include:mail-relay.staff.service.justice.gov.uk -all
+      - v=spf1 ip4:194.33.196.0/24 ip4:194.33.192.0/24 mx a:b.spf.service-now.com a:c.spf.service-now.com a:d.spf.service-now.com include:spf.protection.outlook.com include:_spf.google.com include:mail-relay.staff.service.justice.gov.uk include:amazonses.com -all
       - figma-domain-verification=497c3daab3cae3be9016c8e6c4a5cb0f7864326146415e1986018f7b84151fec-1733823729
       - google-site-verification=TCtRY9C86_qHXCh30w6fLkSQwGgLJG4uXzDorMrByVk
 2ma4ihuxerbnpfigizw76xlnnxmw6zdr._domainkey.magistrates-recruitment:
@@ -506,6 +506,10 @@ administrativecourtoffice:
       - C0E4N61551
       - MS=ms89669471
       - v=spf1 include:spf.protection.outlook.com -all
+agrvnzw2vg3wnycautqlvm6ojvgnoin7._domainkey:
+  ttl: 300
+  type: CNAME
+  value: agrvnzw2vg3wnycautqlvm6ojvgnoin7.dkim.amazonses.com
 aka:
   ttl: 300
   type: CNAME
@@ -907,6 +911,10 @@ eat75rimokuwmhwl3jgruwwxghgmltna._domainkey:
   ttl: 300
   type: CNAME
   value: eat75rimokuwmhwl3jgruwwxghgmltna.dkim.amazonses.com
+ebox3rlb5quorpgarhresfdjxujy4p6y._domainkey:
+  ttl: 300
+  type: CNAME
+  value: ebox3rlb5quorpgarhresfdjxujy4p6y.dkim.amazonses.com
 em3636.cjscp:
   ttl: 300
   type: CNAME
@@ -1531,6 +1539,10 @@ official:
     values:
       - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
       - v=spf1 include:spf.protection.outlook.com -all
+ohxkmhggdywegah3zooonk42ff6u5hjn._domainkey:
+  ttl: 300
+  type: CNAME
+  value: ohxkmhggdywegah3zooonk42ff6u5hjn.dkim.amazonses.com
 one3one:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- The PR adds DNS records to enable the Ardoq service to send email's from an `@justice.gov.uk` email address. This is to reduce emails being treated as spam.

## ♻️ What's changed

- Update SPF TXT record `justice.gov.uk`
- Add CNAME `ohxkmhggdywegah3zooonk42ff6u5hjn._domainkey.justice.gov.uk`
- Add CNAME `agrvnzw2vg3wnycautqlvm6ojvgnoin7._domainkey.justice.gov.uk`
- Add CNAME `ebox3rlb5quorpgarhresfdjxujy4p6y._domainkey.justice.gov.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/Hc2tiOivbi4/m/Z6KKwYZMBwAJ)