### PR TITLE
Add CNAMES for certificate validation

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -350,10 +350,6 @@ _s1xannzcnjxnxzzmilvyaw24hlukg2g.mliveintel:
   ttl: 300
   type: CNAME
   value: dcv.digicert.com.
-s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
 _sip._tcp.meet.video:
   ttl: 300
   type: SRV
@@ -402,6 +398,10 @@ _sipfederationtls._tcp.video:
     priority: 10
     target: sip.video.justice.gov.uk
     weight: 10
+_s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _sips._tcp.meet.video:
   ttl: 300
   type: SRV

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -346,6 +346,14 @@ _pexapp._tcp.video:
       priority: 10
       target: px02.video.justice.gov.uk
       weight: 10
+_s1xannzcnjxnxzzmilvyaw24hlukg2g.mliveintel:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _sip._tcp.meet.video:
   ttl: 300
   type: SRV
@@ -394,14 +402,6 @@ _sipfederationtls._tcp.video:
     priority: 10
     target: sip.video.justice.gov.uk
     weight: 10
-_s1xannzcnjxnxzzmilvyaw24hlukg2g.mliveintel:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
-s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
 _sips._tcp.meet.video:
   ttl: 300
   type: SRV

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -350,6 +350,10 @@ _s1xannzcnjxnxzzmilvyaw24hlukg2g.mliveintel:
   ttl: 300
   type: CNAME
   value: dcv.digicert.com.
+_s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _sip._tcp.meet.video:
   ttl: 300
   type: SRV
@@ -362,10 +366,6 @@ _sip._tcp.meet.video:
       priority: 10
       target: lon-epsig-wrk2.prod.cvp.call.vc.
       weight: 10
-_s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
 _sip._tcp.video:
   ttl: 300
   type: SRV

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -59,10 +59,6 @@ _1b792c2153cf927328615e78010f7852.civilmediation:
   ttl: 300
   type: CNAME
   value: _672e46231dca8c8a2e623dbbe513ce63.ltfvzjuylp.acm-validations.aws.
-_19c1935c338c1a473a54c55c3260a113.mta-sts:
-  ttl: 60
-  type: CNAME
-  value: _deaf7cf7dd6d67b9f69b147486e6a1c9.pczglchxlc.acm-validations.aws.
 _8b3sc3b00nzj1my8ddo4cqmn5kvlbyu.mliveconfig:
   ttl: 300
   type: CNAME
@@ -71,6 +67,10 @@ _8b3sc3b00nzj1my8ddo4cqmn5kvlbyu.www.mliveconfig:
   ttl: 300
   type: CNAME
   value: dcv.digicert.com.
+_19c1935c338c1a473a54c55c3260a113.mta-sts:
+  ttl: 60
+  type: CNAME
+  value: _deaf7cf7dd6d67b9f69b147486e6a1c9.pczglchxlc.acm-validations.aws.
 _956e7fb445bb521906e78cc188987061.mta-sts.administrativecourtoffice:
   ttl: 60
   type: CNAME

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -362,6 +362,10 @@ _sip._tcp.meet.video:
       priority: 10
       target: lon-epsig-wrk2.prod.cvp.call.vc.
       weight: 10
+_s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _sip._tcp.video:
   ttl: 300
   type: SRV
@@ -382,10 +386,6 @@ _sip._tls.administrativecourtoffice:
       priority: 100
       target: sipdir.online.lync.com
       weight: 1
-_s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
 _sipfederationtls._tcp.administrativecourtoffice:
   ttl: 3600
   type: SRV

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -346,14 +346,6 @@ _pexapp._tcp.video:
       priority: 10
       target: px02.video.justice.gov.uk
       weight: 10
-_s1xannzcnjxnxzzmilvyaw24hlukg2g.mliveintel:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
-s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
 _sip._tcp.meet.video:
   ttl: 300
   type: SRV
@@ -446,6 +438,14 @@ _smtp._tls.mappa:
   ttl: 300
   type: TXT
   value: v=TLSRPTv1\;rua=mailto:tls-rua@mailcheck.service.ncsc.gov.uk
+_s1xannzcnjxnxzzmilvyaw24hlukg2g.mliveintel:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 adcourt._domainkey.administrativecourtoffice:
   ttl: 300
   type: TXT

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -382,6 +382,10 @@ _sip._tls.administrativecourtoffice:
       priority: 100
       target: sipdir.online.lync.com
       weight: 1
+_s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _sipfederationtls._tcp.administrativecourtoffice:
   ttl: 3600
   type: SRV
@@ -390,10 +394,6 @@ _sipfederationtls._tcp.administrativecourtoffice:
     priority: 100
     target: sipfed.online.lync.com
     weight: 1
-_s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
 _sipfederationtls._tcp.video:
   ttl: 300
   type: SRV

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -390,6 +390,10 @@ _sipfederationtls._tcp.administrativecourtoffice:
     priority: 100
     target: sipfed.online.lync.com
     weight: 1
+_s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _sipfederationtls._tcp.video:
   ttl: 300
   type: SRV
@@ -398,10 +402,6 @@ _sipfederationtls._tcp.video:
     priority: 10
     target: sip.video.justice.gov.uk
     weight: 10
-_s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
 _sips._tcp.meet.video:
   ttl: 300
   type: SRV

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -63,6 +63,14 @@ _19c1935c338c1a473a54c55c3260a113.mta-sts:
   ttl: 60
   type: CNAME
   value: _deaf7cf7dd6d67b9f69b147486e6a1c9.pczglchxlc.acm-validations.aws.
+_8b3sc3b00nzj1my8ddo4cqmn5kvlbyu.mliveconfig:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_8b3sc3b00nzj1my8ddo4cqmn5kvlbyu.www.mliveconfig:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _956e7fb445bb521906e78cc188987061.mta-sts.administrativecourtoffice:
   ttl: 60
   type: CNAME
@@ -206,6 +214,14 @@ _domainkey.people-development:
   ttl: 300
   type: TXT
   value: t=y\; o=~\;
+_g6youf5vqnvnyxr1fn4fkp5i6nz3aar.mlivemid:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_g6youf5vqnvnyxr1fn4fkp5i6nz3aar.www.mlivemid:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _github-challenge-hmcts:
   ttl: 300
   type: TXT
@@ -330,6 +346,14 @@ _pexapp._tcp.video:
       priority: 10
       target: px02.video.justice.gov.uk
       weight: 10
+_s1xannzcnjxnxzzmilvyaw24hlukg2g.mliveintel:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _sip._tcp.meet.video:
   ttl: 300
   type: SRV

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -394,6 +394,14 @@ _sipfederationtls._tcp.video:
     priority: 10
     target: sip.video.justice.gov.uk
     weight: 10
+_s1xannzcnjxnxzzmilvyaw24hlukg2g.mliveintel:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _sips._tcp.meet.video:
   ttl: 300
   type: SRV
@@ -438,14 +446,6 @@ _smtp._tls.mappa:
   ttl: 300
   type: TXT
   value: v=TLSRPTv1\;rua=mailto:tls-rua@mailcheck.service.ncsc.gov.uk
-_s1xannzcnjxnxzzmilvyaw24hlukg2g.mliveintel:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
-s1xannzcnjxnxzzmilvyaw24hlukg2g.www.mliveintel:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
 adcourt._domainkey.administrativecourtoffice:
   ttl: 300
   type: TXT


### PR DESCRIPTION
Adds CNAMES for certificate validation for the following certificates:

Certificates - 

mliveconfig.justice.gov.uk
mliveintel.justice.gov.uk
mlivemid.justice.gov.uk

CNAMES - 

mliveconfig.justice.gov.uk
www.mliveconfig.justice.gov.uk
mliveintel.justice.gov.uk
www.mliveintel.justice.gov.uk
mlivemid.justice.gov.uk
www.mlivemid.justice.gov.uk