### PR TITLE
Validatets certificate renewal

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -121,6 +121,14 @@ _b932d43205e09e4f3924db0eca5bc86d.dev.creatingfutureopportunities:
   ttl: 300
   type: CNAME
   value: _067ced5bba4174f15cd3b23d291ad16c.sdgjtdhdhz.acm-validations.aws.
+_bwth4blzqa58mllu4u7xkq1yuz0ohfj.apply-for-hmpps-research:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_bwth4blzqa58mllu4u7xkq1yuz0ohfj.www.apply-for-hmpps-research:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _c465a81d426f9c23ea655e52085f8d4a.crown-court-litigator-fees:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
Adds CNAME records to service.justice.gov.uk to validate the following certificate renewal:

apply-for-hmpps-research.service.justice.gov.uk