### PR TITLE
Add ACM validation records for uat.cshrcaseworkcma.justice.gov.uk subdomains

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -31,6 +31,10 @@
   ttl: 300
   type: CNAME
   value: 2ma4ihuxerbnpfigizw76xlnnxmw6zdr.dkim.amazonses.com
+_327813f530886de852b66bc68c3300e0.www.uat.cshrcaseworkcma:
+  ttl: 300
+  type: CNAME
+  value: _5de147b37594c7397631121d423d8197.mhbtsbpdnt.acm-validations.aws.
 4wlxo7xgsbccmlyejcjro4pldynv4jnc._domainkey.optic:
   ttl: 300
   type: CNAME
@@ -153,6 +157,10 @@ _c3e197db2fd6871349b94aaee4fe4c51.mta-sts.cshrcasework:
   ttl: 60
   type: CNAME
   value: _471469039df6a6e4e24c985c337b70a9.zrvsvrxrgs.acm-validations.aws.
+_c7bbc7af90584dc133b1091ece103f81.uat.cshrcaseworkcma:
+  ttl: 300
+  type: CNAME
+  value: _53e1facf76e62874565e3dc1c0084604.mhbtsbpdnt.acm-validations.aws.
 _d97fb4f4ad2c4d0e83508935752915f1.ccmstraining:
   ttl: 300
   type: CNAME

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -47,10 +47,6 @@
   ttl: 300
   type: CNAME
   value: 42qrvtxqjfjkvgvvuwhnbqmj6gjiimyp.dkim.amazonses.com
-_327813f530886de852b66bc68c3300e0.www.uat.cshrcaseworkcma:
-  ttl: 300
-  type: CNAME
-  value: _5de147b37594c7397631121d423d8197.mhbtsbpdnt.acm-validations.aws.
 '#civilmediation':
   ttl: 600
   type: A
@@ -83,6 +79,10 @@ _0970bea3431bc1236acaba02e9f46366.www.civilmediation:
   ttl: 300
   type: CNAME
   value: _06d0edbac8d4d3afa9588239dd3d341d.ltfvzjuylp.acm-validations.aws.
+_327813f530886de852b66bc68c3300e0.www.uat.cshrcaseworkcma:
+  ttl: 300
+  type: CNAME
+  value: _5de147b37594c7397631121d423d8197.mhbtsbpdnt.acm-validations.aws.
 _acme-challenge.aka:
   ttl: 300
   type: CNAME

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -31,10 +31,6 @@
   ttl: 300
   type: CNAME
   value: 2ma4ihuxerbnpfigizw76xlnnxmw6zdr.dkim.amazonses.com
-_327813f530886de852b66bc68c3300e0.www.uat.cshrcaseworkcma:
-  ttl: 300
-  type: CNAME
-  value: _5de147b37594c7397631121d423d8197.mhbtsbpdnt.acm-validations.aws.
 4wlxo7xgsbccmlyejcjro4pldynv4jnc._domainkey.optic:
   ttl: 300
   type: CNAME
@@ -51,6 +47,10 @@ _327813f530886de852b66bc68c3300e0.www.uat.cshrcaseworkcma:
   ttl: 300
   type: CNAME
   value: 42qrvtxqjfjkvgvvuwhnbqmj6gjiimyp.dkim.amazonses.com
+_327813f530886de852b66bc68c3300e0.www.uat.cshrcaseworkcma:
+  ttl: 300
+  type: CNAME
+  value: _5de147b37594c7397631121d423d8197.mhbtsbpdnt.acm-validations.aws.
 '#civilmediation':
   ttl: 600
   type: A


### PR DESCRIPTION
## 👀 Purpose

- This PR adds ACM certificate validation records for `uat.cshrcaseworkcma.justice.gov.uk` and `www.uat.cshrcaseworkcma.justice.gov.uk`

## ♻️ What's changed

- Add CNAME `_c7bbc7af90584dc133b1091ece103f81.uat.cshrcaseworkcma.justice.gov.uk`
- Add CNAME `_327813f530886de852b66bc68c3300e0.www.uat.cshrcaseworkcma.justice.gov.uk`