### PR TITLE
Certificate validation CNAMES

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -75,6 +75,14 @@ _327813f530886de852b66bc68c3300e0.www.uat.cshrcaseworkcma:
   ttl: 300
   type: CNAME
   value: _5de147b37594c7397631121d423d8197.mhbtsbpdnt.acm-validations.aws.
+_41y1v5mq3mc9lb0qo9zaczgjgm5iahj.videoportal:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_41y1v5mq3mc9lb0qo9zaczgjgm5iahj.www.videoportal:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _acme-challenge.aka:
   ttl: 300
   type: CNAME

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -63,6 +63,14 @@ _19c1935c338c1a473a54c55c3260a113.mta-sts:
   ttl: 60
   type: CNAME
   value: _deaf7cf7dd6d67b9f69b147486e6a1c9.pczglchxlc.acm-validations.aws.
+_41y1v5mq3mc9lb0qo9zaczgjgm5iahj.videoportal:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_41y1v5mq3mc9lb0qo9zaczgjgm5iahj.www.videoportal:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _956e7fb445bb521906e78cc188987061.mta-sts.administrativecourtoffice:
   ttl: 60
   type: CNAME
@@ -75,14 +83,6 @@ _327813f530886de852b66bc68c3300e0.www.uat.cshrcaseworkcma:
   ttl: 300
   type: CNAME
   value: _5de147b37594c7397631121d423d8197.mhbtsbpdnt.acm-validations.aws.
-_41y1v5mq3mc9lb0qo9zaczgjgm5iahj.videoportal:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
-_41y1v5mq3mc9lb0qo9zaczgjgm5iahj.www.videoportal:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
 _acme-challenge.aka:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
We had a request to regenerate the following certificate:

videoportal.justice.gov.uk

This PR adds the certificate validation CNAMES:

videoportal.justice.gov.uk
www.videoportal.justice.gov.uk