### PR TITLE
Update judiciary.uk subdomains

### DIFF
--- a/hostedzones/judiciary.uk.yaml
+++ b/hostedzones/judiciary.uk.yaml
@@ -22,7 +22,7 @@
       - d1mkkfanu2t88mqdpc6np4u49r
       - pdk1jsvamjpdtmqi5i8o82ir8s
       - ujatii6o116ahi7u28r22h982t
-      - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32 ip4:78.31.108.141 include:spf.protection.outlook.com include:ciphr247.com -all
+      - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32 ip4:18.132.221.238 include:spf.protection.outlook.com include:ciphr247.com -all
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
       - rfpi1va7dtqmdgthssu2skjjqf
       - vt7q2faup5oj7stn1igpl9m93c
@@ -287,10 +287,10 @@ jcm:
 judicialcareers:
   - ttl: 300
     type: A
-    value: 78.31.108.141
+    value: 18.132.221.238
   - ttl: 300
     type: TXT
-    value: v=spf1 ip4:37.128.132.157 ip4:78.31.108.141 -all
+    value: v=spf1 ip4:18.132.221.238 -all
 ko6w5s55q23tal6ayqic35vnhhwpoam7._domainkey.elinks-staging-email.elinks:
   type: CNAME
   value: ko6w5s55q23tal6ayqic35vnhhwpoam7.dkim.amazonses.com


### PR DESCRIPTION
## 👀 Purpose

- This PR updates `judicial.uk` subdomains to reflect changes to service

## ♻️ What's changed

- Update ARECORD `judicialcareers.judiciary.uk`
- Update TXT RECORD `judicialcareers.judiciary.uk`
- UPDATE TXT RECORD `judiciary.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/hYGBkaZqmGE/m/4Zk7cGPCAwAJ)

**DO NOT MERGE BEFORE 4PM TUESDAY 4TH MARCH**