### PR TITLE
CNAME records for certificate validation

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -63,6 +63,14 @@ _19c1935c338c1a473a54c55c3260a113.mta-sts:
   ttl: 60
   type: CNAME
   value: _deaf7cf7dd6d67b9f69b147486e6a1c9.pczglchxlc.acm-validations.aws.
+_48sinhdp4t3enstqu2zrqkolv7dudt0.staff-staging.court.store.justice.gov.uk:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_48sinhdp4t3enstqu2zrqkolv7dudt0.www.staff-staging.court.store.justice.gov.uk:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _501b4543309e365daa9988b0f8f5bf75.cshrcaseworkcma:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
Add CNAME records to validate renewal of staff-staging.court.store.justice.gov.uk:

staff-staging.court.store.justice.gov.uk
www.staff-staging.court.store.justice.gov.uk