### PR TITLE
Fix CNAMES for cert validation

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -63,11 +63,11 @@ _19c1935c338c1a473a54c55c3260a113.mta-sts:
   ttl: 60
   type: CNAME
   value: _deaf7cf7dd6d67b9f69b147486e6a1c9.pczglchxlc.acm-validations.aws.
-_48sinhdp4t3enstqu2zrqkolv7dudt0.staff-staging.court.store.justice.gov.uk:
+_48sinhdp4t3enstqu2zrqkolv7dudt0.staff-staging.court.store:
   ttl: 300
   type: CNAME
   value: dcv.digicert.com.
-_48sinhdp4t3enstqu2zrqkolv7dudt0.www.staff-staging.court.store.justice.gov.uk:
+_48sinhdp4t3enstqu2zrqkolv7dudt0.www.staff-staging.court.store:
   ttl: 300
   type: CNAME
   value: dcv.digicert.com.


### PR DESCRIPTION
Removes 'justice.gov.uk' from the CNAME entries as not required.  Was causing DNS to not propogate.

Entries amended to:

staff-staging.court.store
www.staff-staging.court.store