### PR TITLE
Add TXT record to complaints.judicialconduct.gov.uk

### DIFF
--- a/hostedzones/judicialconduct.gov.uk.yaml
+++ b/hostedzones/judicialconduct.gov.uk.yaml
@@ -34,6 +34,10 @@ _dmarc:
   ttl: 600
   type: CNAME
   value: _dmarc_ttp_policy.justice.gov.uk
+_dnsauth.www.complaints
+  ttl: 300
+  type: TXT
+  value: _klnxckldzco3b6q4qdex5id87b9s9v2
 _mta-sts:
   ttl: 300
   type: TXT

--- a/hostedzones/judicialconduct.gov.uk.yaml
+++ b/hostedzones/judicialconduct.gov.uk.yaml
@@ -34,7 +34,7 @@ _dmarc:
   ttl: 600
   type: CNAME
   value: _dmarc_ttp_policy.justice.gov.uk
-_dnsauth.www.complaints
+_dnsauth.www.complaints:
   ttl: 300
   type: TXT
   value: _klnxckldzco3b6q4qdex5id87b9s9v2


### PR DESCRIPTION
## 👀 Purpose

- This PR adds a new TXT validation record to complaints.judicialconduct.gov.uk. Prerequisite change for upcoming WAF enablement.

## ♻️ What's changed

- Add TXT record `_dnsauth.www.complaints.judicialconduct.gov.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/1ubsLRKWU8U/m/iPYsPiLQAAAJ)