### PR TITLE
Add search-policy-and-guidance.paroleboard.gov.uk

### DIFF
--- a/hostedzones/paroleboard.gov.uk.yaml
+++ b/hostedzones/paroleboard.gov.uk.yaml
@@ -74,6 +74,10 @@ remote:
   ttl: 600
   type: A
   value: 51.140.159.248
+search-policy-and-guidance:
+  ttl: 300
+  type: A
+  value: 20.90.134.13
 selector1._domainkey:
   type: CNAME
   value: selector1-paroleboard-gov-uk._domainkey.digitalparole.onmicrosoft.com


### PR DESCRIPTION
## 👀 Purpose

- This PR adds new subdomain `search-policy-and-guidance.paroleboard.gov.uk`

## ♻️ What's changed

- Add ARECORD `search-policy-and-guidance.paroleboard.gov.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/x8WWtP7d8RA/m/S-rKPDEpAgAJ)