### PR TITLE
Reverts incorrect DNS change

### DIFF
--- a/hostedzones/brookhouseinvestigation.independent.gov.uk.yaml
+++ b/hostedzones/brookhouseinvestigation.independent.gov.uk.yaml
@@ -31,4 +31,4 @@
 _dmarc:
   ttl: 300
   type: TXT
-  value: v=DMARC1; p=reject; sp=reject; fo=1; ri=3600; rua=mailto:ukho@rua.agari-eu.com,mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:ukho@ruf.agari-eu.com;
+  value: v=DMARC1;p=reject;sp=reject;rua=mailto:dmarc-rua@dmarc.service.gov.uk


### PR DESCRIPTION
Reverts the brookhouse _dmarc change made earlier [#391](https://github.com/ministryofjustice/dns/pull/391) as it's in the wrong hostedzone 😊 

