### PR TITLE
Add email DNS records for nottinghaminquiry.uk

### DIFF
--- a/hostedzones/nottinghaminquiry.uk.yaml
+++ b/hostedzones/nottinghaminquiry.uk.yaml
@@ -17,6 +17,6 @@
     value:
       exchange: NottinghamInquiry-uk.mail.protection.outlook.com
       preference: 0
-  -ttl: 3600
+  - ttl: 3600
     type: CNAME
     value: autodiscover.outlook.com

--- a/hostedzones/nottinghaminquiry.uk.yaml
+++ b/hostedzones/nottinghaminquiry.uk.yaml
@@ -9,4 +9,14 @@
       - ns-1828.awsdns-36.co.uk.
   - ttl: 3600
     type: TXT
-    value: MS=ms43303837
+    values:
+      - MS=ms43303837
+      - v=spf1 include:spf.protection.outlook.com -all
+  - ttl: 3600
+    type: MX
+    value:
+      exchange: NottinghamInquiry-uk.mail.protection.outlook.com
+      preference: 0
+  -ttl: 3600
+    type: CNAME
+    value: autodiscover.outlook.com


### PR DESCRIPTION
## 👀 Purpose

- This PR adds DNS records to enable domain to be used for email purposes.

## ♻️ What's changed

- Add MX Record `nottinghaminquiry.uk`
- Add CNAME `nottinghaminquiry.uk`
- Update TXT Record `nottinghaminquiry.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/e9uipEt8c1U/m/zHeeJYazAQAJ)