### PR TITLE
Add certification validation CNAMES

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -109,6 +109,14 @@ _acme-challenge.c100formsurvey-staging:
   ttl: 60
   type: TXT
   value: h3EfKuixfZMRj30lClIYS1M7Xivu2Ccp06WwgwiTgik
+_ahe8a4d7t5qc853pu0dncis2ue5plf3.apply-for-hmpps-research:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_ahe8a4d7t5qc853pu0dncis2ue5plf3.www.apply-for-hmpps-research:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _adsp._domainkey.recruitment:
   ttl: 300
   type: TXT


### PR DESCRIPTION
Request to create a new certificate for apply-for-hmpps-research.service.justice.gov.uk.

Add the following CNAMES for certificate validation:

 - apply-for-hmpps-research.service.justice.gov.uk
 - www.apply-for-hmpps-research.service.justice.gov.uk