### PR TITLE
Add gand.net cert validation CNAMES for waminternaltest.ppud.justice.gov.uk

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -59,6 +59,14 @@ _1b792c2153cf927328615e78010f7852.civilmediation:
   ttl: 300
   type: CNAME
   value: _672e46231dca8c8a2e623dbbe513ce63.ltfvzjuylp.acm-validations.aws.
+_7f4f2ufikmyf9ve4ktyodo7dd67iz0u.waminternaltest.ppud:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_7f4f2ufikmyf9ve4ktyodo7dd67iz0u.www.waminternaltest.ppud:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _19c1935c338c1a473a54c55c3260a113.mta-sts:
   ttl: 60
   type: CNAME
@@ -79,14 +87,6 @@ _327813f530886de852b66bc68c3300e0.www.uat.cshrcaseworkcma:
   ttl: 300
   type: CNAME
   value: _5de147b37594c7397631121d423d8197.mhbtsbpdnt.acm-validations.aws.
-_7f4f2ufikmyf9ve4ktyodo7dd67iz0u.waminternaltest.ppud:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
-_7f4f2ufikmyf9ve4ktyodo7dd67iz0u.www.waminternaltest.ppud:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
 _acme-challenge.aka:
   ttl: 300
   type: CNAME

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -43,6 +43,14 @@
   ttl: 300
   type: CNAME
   value: 6zbhv7347nomwa5tilvvgcmsdknyag4i.dkim.amazonses.com
+_7f4f2ufikmyf9ve4ktyodo7dd67iz0u.waminternaltest.ppud:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_7f4f2ufikmyf9ve4ktyodo7dd67iz0u.www.waminternaltest.ppud:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 42qrvtxqjfjkvgvvuwhnbqmj6gjiimyp._domainkey.cshrcaseworkcma:
   ttl: 300
   type: CNAME

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -43,14 +43,6 @@
   ttl: 300
   type: CNAME
   value: 6zbhv7347nomwa5tilvvgcmsdknyag4i.dkim.amazonses.com
-_7f4f2ufikmyf9ve4ktyodo7dd67iz0u.waminternaltest.ppud:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
-_7f4f2ufikmyf9ve4ktyodo7dd67iz0u.www.waminternaltest.ppud:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
 42qrvtxqjfjkvgvvuwhnbqmj6gjiimyp._domainkey.cshrcaseworkcma:
   ttl: 300
   type: CNAME
@@ -87,6 +79,14 @@ _327813f530886de852b66bc68c3300e0.www.uat.cshrcaseworkcma:
   ttl: 300
   type: CNAME
   value: _5de147b37594c7397631121d423d8197.mhbtsbpdnt.acm-validations.aws.
+_7f4f2ufikmyf9ve4ktyodo7dd67iz0u.waminternaltest.ppud:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_7f4f2ufikmyf9ve4ktyodo7dd67iz0u.www.waminternaltest.ppud:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 _acme-challenge.aka:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- The PR adds gandi.net cert validation records for renewed cert for `waminternaltest.ppud.justice.gov.uk`

## ♻️ What's changed

- Add CNAME `_7f4f2ufikmyf9ve4ktyodo7dd67iz0u.waminternaltest.ppud.justice.gov.uk`
- Add CNAME `_7f4f2ufikmyf9ve4ktyodo7dd67iz0u.www.waminternaltest.ppud.justice.gov.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/certificates/c/G6ySPJxn7bo/m/h1Er0F1_BgAJ)