### PR TITLE
Add staging.xhibit.justice.gov.uk

### DIFF
--- a/hostedzones/xhibit.justice.gov.uk.yaml
+++ b/hostedzones/xhibit.justice.gov.uk.yaml
@@ -18,6 +18,14 @@ _60ea7b43706335f0bb1c92131c8324b6:
   ttl: 300
   type: CNAME
   value: _01043a23fa206ed27aef9e1016547f29.acm-validations.aws.
+staging:
+  ttl: 942942942
+  type: Route53Provider/ALIAS
+  value:
+    evaluate-target-health: false
+    hosted-zone-id: Z38I13QAYD1LX
+    name: d2r40au2vo779k.cloudfront.net.
+    type: A
 www:
   ttl: 942942942
   type: Route53Provider/ALIAS


### PR DESCRIPTION
## 👀 Purpose

- This PR adds new subdomain for `staging.xhibit.justice.gov.uk`

## ♻️ What's changed

- Add ARECORD `staging.xhibit.justice.gov.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/4b1RE4oRdso/m/wRIrqcsACAAJ)