### PR TITLE
Add TXT record to independentpublicadvocate.org.uk

### DIFF
--- a/hostedzones/independentpublicadvocate.org.uk.yaml
+++ b/hostedzones/independentpublicadvocate.org.uk.yaml
@@ -23,7 +23,7 @@
       - ns-532.awsdns-02.net.
   - ttl: 3600
     type: TXT
-    values: 
+    values:
       - v=spf1 -all
       - MS=ms10455819
 '*._domainkey':

--- a/hostedzones/independentpublicadvocate.org.uk.yaml
+++ b/hostedzones/independentpublicadvocate.org.uk.yaml
@@ -21,9 +21,11 @@
       - ns-1712.awsdns-22.co.uk.
       - ns-37.awsdns-04.com.
       - ns-532.awsdns-02.net.
-  - ttl: 300
+  - ttl: 3600
     type: TXT
-    value: v=spf1 -all
+    values: 
+      - v=spf1 -all
+      - MS=ms10455819
 '*._domainkey':
   ttl: 300
   type: TXT


### PR DESCRIPTION
## 👀 Purpose

- The PR adds a TXT validation record to `independentpublicadvocate.org.uk`. This is to register the domain in O365 tenant.

## ♻️ What's changed

-Update TXT record `independentpublicadvocate.org.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/S93zntp7XpM/m/EPZPddS2CwAJ)