### PR TITLE
Add new email DNS configuration for independentpublicadvocate.org.uk

### DIFF
--- a/hostedzones/independentpublicadvocate.co.uk.yaml
+++ b/hostedzones/independentpublicadvocate.co.uk.yaml
@@ -1,18 +1,9 @@
 ---
 '':
-  - ttl: 300
-    type: CAA
-    values:
-      - flags: 0
-        tag: iodef
-        value: mailto:certificates@digital.justice.gov.uk
-      - flags: 0
-        tag: issue
-        value: ;
-  - ttl: 300
+  - ttl: 3600
     type: MX
     value:
-      exchange: .
+      exchange: independentpublicadvocate-org-uk.mail.protection.outlook.com.
       preference: 0
   - ttl: 172800
     type: NS
@@ -21,14 +12,10 @@
       - ns-1949.awsdns-51.co.uk.
       - ns-243.awsdns-30.com.
       - ns-853.awsdns-42.net.
-  - ttl: 300
+  - ttl: 3600
     type: TXT
-    value: v=spf1 -all
-'*._domainkey':
-  ttl: 300
-  type: TXT
-  value: v=DKIM1\; p=
-_dmarc:
-  ttl: 300
-  type: TXT
-  value: v=DMARC1\;p=reject\;sp=reject\;rua=mailto:dmarc-rua@dmarc.service.gov.uk\;
+    value: v=spf1 include:spf.protection.outlook.com -all
+autodiscover:
+  - ttl: 3600
+  - type: CNAME
+  - value: autodiscover.outlook.com.


### PR DESCRIPTION
## 👀 Purpose

- This PR add new DNS records for new email service. It also removes defensive domain configuration as the domain will now be in use.

## ♻️ What's changed

- Update MX `independentpublicadvocate.org.uk`
- Update TXT `independentpublicadvocate.org.uk`
- Add CNAME `autodiscoverer.independentpublicadvocate.org.uk`
- Delete CAA `independentpublicadvocate.org.uk`
- Delete TXT `*._domainkey.independentpublicadvocate.org.uk`
- Delete TXT `_dmarc.independentpublicadvocate.org.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/S93zntp7XpM/m/EPZPddS2CwAJ)