### PR TITLE
Add new email DNS configuration for independentpublicadvocate.org.uk

### DIFF
--- a/hostedzones/independentpublicadvocate.org.uk.yaml
+++ b/hostedzones/independentpublicadvocate.org.uk.yaml
@@ -14,7 +14,7 @@
       - ns-532.awsdns-02.net.
   - ttl: 3600
     type: TXT
-    values: 
+    values:
       - v=spf1 include:spf.protection.outlook.com -all
       - MS=ms14912346
 autodiscover:

--- a/hostedzones/independentpublicadvocate.org.uk.yaml
+++ b/hostedzones/independentpublicadvocate.org.uk.yaml
@@ -1,36 +1,23 @@
 ---
 '':
-  - ttl: 300
-    type: CAA
-    values:
-      - flags: 0
-        tag: iodef
-        value: mailto:certificates@digital.justice.gov.uk
-      - flags: 0
-        tag: issue
-        value: ;
-  - ttl: 300
+  - ttl: 3600
     type: MX
     value:
-      exchange: .
+      exchange: independentpublicadvocate-org-uk.mail.protection.outlook.com.
       preference: 0
   - ttl: 172800
     type: NS
     values:
-      - ns-1190.awsdns-20.org.
-      - ns-1712.awsdns-22.co.uk.
-      - ns-37.awsdns-04.com.
-      - ns-532.awsdns-02.net.
+      - ns-1406.awsdns-47.org.
+      - ns-1949.awsdns-51.co.uk.
+      - ns-243.awsdns-30.com.
+      - ns-853.awsdns-42.net.
   - ttl: 3600
     type: TXT
-    values:
-      - v=spf1 -all
+    values: 
+      - v=spf1 include:spf.protection.outlook.com -all
       - MS=ms14912346
-'*._domainkey':
-  ttl: 300
-  type: TXT
-  value: v=DKIM1\; p=
-_dmarc:
-  ttl: 300
-  type: TXT
-  value: v=DMARC1\;p=reject\;sp=reject\;rua=mailto:dmarc-rua@dmarc.service.gov.uk\;
+autodiscover:
+  - ttl: 3600
+  - type: CNAME
+  - value: autodiscover.outlook.com.

--- a/hostedzones/independentpublicadvocate.org.uk.yaml
+++ b/hostedzones/independentpublicadvocate.org.uk.yaml
@@ -8,10 +8,10 @@
   - ttl: 172800
     type: NS
     values:
-      - ns-1406.awsdns-47.org.
-      - ns-1949.awsdns-51.co.uk.
-      - ns-243.awsdns-30.com.
-      - ns-853.awsdns-42.net.
+      - ns-1190.awsdns-20.org.
+      - ns-1712.awsdns-22.co.uk.
+      - ns-37.awsdns-04.com.
+      - ns-532.awsdns-02.net.
   - ttl: 3600
     type: TXT
     values: 

--- a/hostedzones/independentpublicadvocate.org.uk.yaml
+++ b/hostedzones/independentpublicadvocate.org.uk.yaml
@@ -19,5 +19,5 @@
       - MS=ms14912346
 autodiscover:
   - ttl: 3600
-  - type: CNAME
-  - value: autodiscover.outlook.com.
+    type: CNAME
+    value: autodiscover.outlook.com.


### PR DESCRIPTION
## 👀 Purpose

- This PR add new DNS records for new email service. It also removes defensive domain configuration as the domain will now be in use.

## ♻️ What's changed

- Update MX `independentpublicadvocate.org.uk`
- Update TXT `independentpublicadvocate.org.uk`
- Add CNAME `autodiscoverer.independentpublicadvocate.org.uk`
- Delete CAA `independentpublicadvocate.org.uk`
- Delete TXT `*._domainkey.independentpublicadvocate.org.uk`
- Delete TXT `_dmarc.independentpublicadvocate.org.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/S93zntp7XpM/m/EPZPddS2CwAJ)