### PR TITLE
Delegate cdpt-metabase.service.justice.gov.uk to Cloud Platform

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -486,6 +486,14 @@ ccms-ebs:
     - ns-1743.awsdns-25.co.uk.
     - ns-22.awsdns-02.com.
     - ns-760.awsdns-31.net.
+cdpt-metabase:
+  ttl: 86400
+  type: NS
+  values:
+    - ns-98.awsdns-12.com.
+    - ns-1483.awsdns-57.org.
+    - ns-1565.awsdns-03.co.uk.
+    - ns-539.awsdns-03.net.
 check-clients-details-using-hmrc-data:
   ttl: 300
   type: NS


### PR DESCRIPTION
## 👀 Purpose

- This PR delegates subdomain `cdpt-metabase.service.justice.gov.uk` to the Cloud Platform.

## ♻️ What's changed

- Add NS Record `cdpt-metabase.service.justice.gov.uk`

## 📝 Notes

- [Request](https://mojdt.slack.com/archives/C01BUKJSZD4/p1744792108692819)