### PR TITLE
Update xhibit.justice.gov.uk alias records

### DIFF
--- a/hostedzones/xhibit.justice.gov.uk.yaml
+++ b/hostedzones/xhibit.justice.gov.uk.yaml
@@ -11,8 +11,8 @@
     type: Route53Provider/ALIAS
     value:
       evaluate-target-health: false
-      hosted-zone-id: Z1BKCTXD74EZPE
-      name: s3-website-eu-west-1.amazonaws.com.
+      hosted-zone-id: Z2FDTNDATAQYW2
+      name: d3hp45qjxidopf.cloudfront.net.
       type: A
 _60ea7b43706335f0bb1c92131c8324b6:
   ttl: 300
@@ -31,6 +31,6 @@ www:
   type: Route53Provider/ALIAS
   value:
     evaluate-target-health: false
-    hosted-zone-id: Z1BKCTXD74EZPE
-    name: s3-website-eu-west-1.amazonaws.com.
+    hosted-zone-id: Z2FDTNDATAQYW2
+    name: d3hp45qjxidopf.cloudfront.net.
     type: A


### PR DESCRIPTION
## 👀 Purpose

- This PR updates production `xhibit.justice.gov.uk` alias records following migration to new hosting.

## ♻️ What's changed

- Update ALIAS `xhibit.justice.gov.uk`
- Update ALIAS `www.xhibit.justice.gov.uk`

## 📝 Notes

- [Request](https://groups.google.com/a/digital.justice.gov.uk/g/domains/c/4b1RE4oRdso/m/UPCO04fqCgAJ)