### PR TITLE
Add ChatGpt verification TXT records for email domains

### DIFF
--- a/hostedzones/cica.gov.uk.yaml
+++ b/hostedzones/cica.gov.uk.yaml
@@ -28,6 +28,7 @@
       - w6xmnnqn2r3vnry0c5n5sg3dg25wvlln
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
       - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
+      - openai-domain-verification=dv-ngG4v2ov7T4yeUMV0ZVTr07D
 _56a37ebc38b8f47a75fe557fc29d22dd.mta-sts:
   ttl: 60
   type: CNAME

--- a/hostedzones/judiciary.uk.yaml
+++ b/hostedzones/judiciary.uk.yaml
@@ -27,6 +27,7 @@
       - rfpi1va7dtqmdgthssu2skjjqf
       - vt7q2faup5oj7stn1igpl9m93c
       - atlassian-domain-verification=vAjh0qsG/yJoMmOv6nM3A9a22B7Nc8acyzKreuqgTeiCjHkRxYoi6ZGQHNuU82Ua
+      - openai-domain-verification=dv-aCcMTlHqMQa3ducHk6rPfK3S
 5vl4vla56j76p3obneqqnjelrynl2kiv._domainkey.elinks-staging-email.elinks:
   type: CNAME
   value: 5vl4vla56j76p3obneqqnjelrynl2kiv.dkim.amazonses.com

--- a/hostedzones/publicguardian.gov.uk.yaml
+++ b/hostedzones/publicguardian.gov.uk.yaml
@@ -29,6 +29,7 @@
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
       - google-gws-recovery-domain-verification=57195953
       - google-site-verification=kvDuEESo0CdZs7pRtvXEoy7L176lTbyQqsFPo-v2qbw
+      - openai-domain-verification=dv-q3SRBK5mWbWJb4kyNNUpUkei
 _asvdns-8a5e9946-76d7-4e78-83b0-5f3be2e0e7b0:
   ttl: 300
   type: TXT


### PR DESCRIPTION
## 👀 Purpose

- This PR adds TXT verification record to `cica.gov.uk`, `judiciary.uk` and  `publicguardian.gov.uk` to enable SSO for the MoJ ChatGPT subscription.

## ♻️ What's changed

- Update `cica.gov.uk` TXT record
- Update `judiciary.uk` TXT record
- Update `publicguardian.gov.uk` TXT record