### PR TITLE
Remove dangling CNAME

### DIFF
--- a/hostedzones/judiciary.gov.uk.yaml
+++ b/hostedzones/judiciary.gov.uk.yaml
@@ -117,10 +117,6 @@ sec:
   ttl: 600
   type: A
   value: 94.236.26.129
-sentencingcouncil:
-  ttl: 600
-  type: CNAME
-  value: sentencing-judiciary.live.bangdynamics.com.
 smtp:
   ttl: 600
   type: A


### PR DESCRIPTION
This PR removes dangling CNAME `sentencingcouncil.judiciary.gov.uk`.