### PR TITLE
Remove lawcommission.intranet.service.justice.gov.uk

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1014,10 +1014,6 @@ laa-status-dashboard:
     - ns-1723.awsdns-23.co.uk.
     - ns-209.awsdns-26.com.
     - ns-925.awsdns-51.net.
-lawcommission.intranet:
-  ttl: 300
-  type: CNAME
-  value: lawcomintranet.prod.wp.dsd.io
 legacy.manage-external-funded-offender-provision:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
This PR removed `lawcommission.intranet.service.justice.gov.uk` as domain is no longer in use.