### PR TITLE
Remove search.sentencingcouncil.org.uk

### DIFF
--- a/hostedzones/sentencingcouncil.org.uk.yaml
+++ b/hostedzones/sentencingcouncil.org.uk.yaml
@@ -48,10 +48,6 @@ mta-sts:
     hosted-zone-id: Z2FDTNDATAQYW2
     name: dsabyr6tawzy4.cloudfront.net.
     type: A
-search:
-  ttl: 600
-  type: CNAME
-  value: search2.openobjects.com.
 www:
   ttl: 1800
   type: CNAME


### PR DESCRIPTION
This PR removes `search.sentencingcouncil.org.uk` as record is no longer in use.