### PR TITLE
Remove old OpenAI TXT validation records

### DIFF
--- a/hostedzones/cica.gov.uk.yaml
+++ b/hostedzones/cica.gov.uk.yaml
@@ -28,7 +28,6 @@
       - w6xmnnqn2r3vnry0c5n5sg3dg25wvlln
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
       - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
-      - openai-domain-verification=dv-ngG4v2ov7T4yeUMV0ZVTr07D
       - openai-domain-verification=dv-Q3prkKonRc2hFj5Xa8uAaI2b
 _56a37ebc38b8f47a75fe557fc29d22dd.mta-sts:
   ttl: 60

--- a/hostedzones/judiciary.uk.yaml
+++ b/hostedzones/judiciary.uk.yaml
@@ -27,7 +27,6 @@
       - rfpi1va7dtqmdgthssu2skjjqf
       - vt7q2faup5oj7stn1igpl9m93c
       - atlassian-domain-verification=vAjh0qsG/yJoMmOv6nM3A9a22B7Nc8acyzKreuqgTeiCjHkRxYoi6ZGQHNuU82Ua
-      - openai-domain-verification=dv-aCcMTlHqMQa3ducHk6rPfK3S
       - openai-domain-verification=dv-zpF9jWw43jaejkh4OyerdbFJ
 _2cfb3230475e3689609b3297ae4656c4:
   ttl: 300

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -28,7 +28,6 @@
       - figma-domain-verification=497c3daab3cae3be9016c8e6c4a5cb0f7864326146415e1986018f7b84151fec-1733823729
       - google-site-verification=TCtRY9C86_qHXCh30w6fLkSQwGgLJG4uXzDorMrByVk
       - atlassian-domain-verification=vAjh0qsG/yJoMmOv6nM3A9a22B7Nc8acyzKreuqgTeiCjHkRxYoi6ZGQHNuU82Ua
-      - openai-domain-verification=dv-PuG0ZW850KPG5jzX2cnmvGjq
       - openai-domain-verification=dv-K7YKE7fDeUHEZaXrnMLEVLOQ
 2ma4ihuxerbnpfigizw76xlnnxmw6zdr._domainkey.magistrates-recruitment:
   ttl: 300

--- a/hostedzones/publicguardian.gov.uk.yaml
+++ b/hostedzones/publicguardian.gov.uk.yaml
@@ -29,7 +29,6 @@
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
       - google-gws-recovery-domain-verification=57195953
       - google-site-verification=kvDuEESo0CdZs7pRtvXEoy7L176lTbyQqsFPo-v2qbw
-      - openai-domain-verification=dv-q3SRBK5mWbWJb4kyNNUpUkei
       - openai-domain-verification=dv-horegd4wk8DAhov1eFYWXQwu
 _asvdns-8a5e9946-76d7-4e78-83b0-5f3be2e0e7b0:
   ttl: 300


### PR DESCRIPTION
## 👀 Purpose

- This PR removes old OpenAI TXT validation records. This is in support of the move to an EU based tenant.

## ♻️ What's changed

- Update TXT `justice.gov.uk`
- Update TXT `cica.gov.uk`
- Update TXT `judiciary.uk`
- Update TXT `publicguardian.gov.uk`