### PR TITLE
Remove email related DNS records for sentencingcouncil.org.uk

### DIFF
--- a/hostedzones/sentencingcouncil.org.uk.yaml
+++ b/hostedzones/sentencingcouncil.org.uk.yaml
@@ -10,10 +10,6 @@
       - ns-1947.awsdns-51.co.uk.
       - ns-337.awsdns-42.com.
       - ns-771.awsdns-32.net.
-_asvdns-82dce4ea-c071-49e9-9164-f556aa6a2d32:
-  ttl: 300
-  type: TXT
-  value: asvdns_c07dc387-d9a1-4d54-a531-27effdd26842
 _c118dcb76f6b712bb5fc5d2514f42d46.mta-sts:
   ttl: 60
   type: CNAME

--- a/hostedzones/sentencingcouncil.org.uk.yaml
+++ b/hostedzones/sentencingcouncil.org.uk.yaml
@@ -10,6 +10,10 @@
       - ns-1947.awsdns-51.co.uk.
       - ns-337.awsdns-42.com.
       - ns-771.awsdns-32.net.
+_asvdns-82dce4ea-c071-49e9-9164-f556aa6a2d32:
+  ttl: 300
+  type: TXT
+  value: asvdns_c07dc387-d9a1-4d54-a531-27effdd26842
 _c118dcb76f6b712bb5fc5d2514f42d46.mta-sts:
   ttl: 60
   type: CNAME

--- a/hostedzones/sentencingcouncil.org.uk.yaml
+++ b/hostedzones/sentencingcouncil.org.uk.yaml
@@ -3,13 +3,6 @@
   - ttl: 600
     type: A
     value: 35.177.235.232
-  - ttl: 600
-    type: MX
-    values:
-      - exchange: mx1.bangdynamics.com.
-        preference: 10
-      - exchange: mx2.bangdynamics.com.
-        preference: 20
   - ttl: 172800
     type: NS
     values:
@@ -17,9 +10,6 @@
       - ns-1947.awsdns-51.co.uk.
       - ns-337.awsdns-42.com.
       - ns-771.awsdns-32.net.
-  - ttl: 300
-    type: TXT
-    value: v=spf1 a mx ~all
 _asvdns-82dce4ea-c071-49e9-9164-f556aa6a2d32:
   ttl: 300
   type: TXT
@@ -28,10 +18,6 @@ _c118dcb76f6b712bb5fc5d2514f42d46.mta-sts:
   ttl: 60
   type: CNAME
   value: _fe3ef0a59165845368320f32ba38ee8e.nhsllhhtvj.acm-validations.aws.
-_dmarc:
-  ttl: 300
-  type: TXT
-  value: v=DMARC1\;p=none\;sp=none\;fo=1\;rua=mailto:dmarc-rua@dmarc.service.gov.uk
 _mta-sts:
   ttl: 300
   type: TXT

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -795,14 +795,6 @@ familymediators:
     - ns-1813.awsdns-34.co.uk.
     - ns-500.awsdns-62.com.
     - ns-912.awsdns-50.net.
-find-google-file:
-  ttl: 300
-  type: NS
-  values:
-    - ns-1344.awsdns-40.org.
-    - ns-1617.awsdns-10.co.uk.
-    - ns-348.awsdns-43.com.
-    - ns-988.awsdns-59.net.
 find-moj-data:
   ttl: 86400
   type: NS

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -795,6 +795,14 @@ familymediators:
     - ns-1813.awsdns-34.co.uk.
     - ns-500.awsdns-62.com.
     - ns-912.awsdns-50.net.
+find-google-file:
+  ttl: 300
+  type: NS
+  values:
+    - ns-1344.awsdns-40.org.
+    - ns-1617.awsdns-10.co.uk.
+    - ns-348.awsdns-43.com.
+    - ns-988.awsdns-59.net.
 find-moj-data:
   ttl: 86400
   type: NS


### PR DESCRIPTION
## 👀 Purpose

- Remove DNS records delating to legacy email service for sentencingcouncil.org.uk that is no longer is use.

## ♻️ What's changed

- Delete MX `sentencingcouncil.org.uk`
- Delete TXT `sentencingcouncil.org.uk`
- Delete TXT `_dmarc.sentencingcouncil.org.uk`
- Delete TXT `_asvdns-82dce4ea-c071-49e9-9164-f556aa6a2d32.sentencingcouncil.org.uk`

## 📝 Notes

- MTA-STS records can not yet be removed but will be decommissioning in 14 days in line with MTA-STS decommissioning process.