### PR TITLE
Remove certificate validation key

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -359,10 +359,6 @@ _smtp._tls:
   ttl: 300
   type: TXT
   value: v=TLSRPTv1\;rua=mailto:tls-rua@mailcheck.service.ncsc.gov.uk
-_ujpkhbu0nqm5hbjue49hx3xz66dq2bc.equip:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
 access.platforms:
   type: NS
   values:


### PR DESCRIPTION
Created a new wildcard certificate for *.equip.service.justice.go.uk

Initially pushed up a change to add certificate validation CNAME.  However this is delegated and we do not manage the DNS, so I am reverting the change by removing the CNAME key.