### PR TITLE
Add OpenAI TXT Validation records

### DIFF
--- a/hostedzones/govfsl.com.yaml
+++ b/hostedzones/govfsl.com.yaml
@@ -22,6 +22,7 @@
       - v=spf1 include:spf.protection.outlook.com include:spf_c.oracle.com include:spf_c.oraclecloud.com ip4:188.65.119.39 ip4:188.65.119.42 ip4:87.247.244.98 ip4:195.62.28.68 ip4:185.24.97.25 -all
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
       - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
+      - openai-domain-verification=dv-7V2ew1gVYHyb1v6qudyNrZZP
 _94027e3232a87bef15c3cfb7834ff05c.mta-sts:
   ttl: 60
   type: CNAME

--- a/hostedzones/hmiprobation.gov.uk.yaml
+++ b/hostedzones/hmiprobation.gov.uk.yaml
@@ -19,6 +19,7 @@
       - v=spf1 include:_spf.mlsend.com ip4:194.33.196.8/32 ip4:194.33.192.8/32 include:spf.protection.outlook.com
         -all
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
+      - openai-domain-verification=dv-nenTePzIy8R3cBqNQiZApJZz
 _90a26ed25d4dc817fe7ddb874d5fc26c.mta-sts:
   ttl: 60
   type: CNAME

--- a/hostedzones/ima-citizensrights.org.uk.yaml
+++ b/hostedzones/ima-citizensrights.org.uk.yaml
@@ -23,6 +23,7 @@
       - google-site-verification=ZF9wtpT_YiWaUp4t18aOheIRck4ZM6F4ejm80HGAsmc
       - v=spf1 mx ip4:194.33.196.0/24 ip4:194.33.192.0/24 include:spf.protection.outlook.com include:_spf.google.com include:spf.mandrillapp.com -all
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
+      - openai-domain-verification=dv-reBVNpFQ525quczdx3kxrQpP
 129688:
   ttl: 300
   type: CNAME

--- a/hostedzones/judicialappointments.gov.uk.yaml
+++ b/hostedzones/judicialappointments.gov.uk.yaml
@@ -25,6 +25,7 @@
       - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32  include:spf.protection.outlook.com
         -all
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
+      - openai-domain-verification=dv-gXY7MAiAOTilu9e4RVzySI3U
 _6351f8e182881f77d161743e5cf255f9.mta-sts:
   ttl: 60
   type: CNAME

--- a/hostedzones/lawcommission.gov.uk.yaml
+++ b/hostedzones/lawcommission.gov.uk.yaml
@@ -18,6 +18,7 @@
       - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32  include:spf.protection.outlook.com
         -all
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
+      - openai-domain-verification=dv-g6sLeaspwAb5gtI16d1YxOb6
 129688:
   type: CNAME
   value: sendgrid.net

--- a/hostedzones/ospt.gov.uk.yaml
+++ b/hostedzones/ospt.gov.uk.yaml
@@ -25,6 +25,7 @@
       - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32  include:spf.protection.outlook.com
         -all
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
+      - openai-domain-verification=dv-XgHgICZMngFFsENuar2oGiXo
 47klhk64a2fmag4rljvb7umybpa22yff._domainkey:
   ttl: 300
   type: CNAME

--- a/hostedzones/yjb.gov.uk.yaml
+++ b/hostedzones/yjb.gov.uk.yaml
@@ -26,6 +26,7 @@
       - v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32 ip4:5.61.115.16/28  include:spf.protection.outlook.com
         -all
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
+      - openai-domain-verification=dv-KB38UaPRlySfCNSkLPKqSZaZ
 2dbx4addpy7nyj76mioylqhzphrymyma._domainkey:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR adds OpenAI TXT validation records to a number of email domains. This will allow use of SSO with OpenAI tenant.

## ♻️ What's changed

- Update TXT `yjb.gov.uk`
- Update TXT `ima-citizensrights.org.uk`
- Update TXT `judicialappointments.gov.uk`
- Update TXT `ospt.gov.uk`
- Update TXT `hmiprobation.gov.uk`
- Update TXT `govfsl.com`
- Update TXT `lawcommission.gov.uk`