### PR TITLE
Add production laa-online subdomains

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -163,10 +163,18 @@ _dmarc.recruitment:
   ttl: 300
   type: TXT
   value: v=DMARC1\;p=none\;rua=mailto:N4rHXmBVPY@dmarc.inboxmonster.com\;fo=0\;adkim=r\;aspf=r\;rf=afrf\;pct=100\;
+_dnsauth.manage.laa-online:
+  ttl: 300
+  type: TXT
+  value: _guqranwdfrzf1hrjj69pcrrh881x8dn
 _dnsauth.manage.dev.laa-online:
   ttl: 300
   type: TXT
   value: _c10if6cs0hjwzkve54i6zzaro6l1c0w
+_dnsauth.register.laa-online:
+  ttl: 300
+  type: TXT
+  value: _7mxda2m7si2greeh8ddkgy6j1qugjm5
 _dnsauth.register.dev.laa-online:
   ttl: 300
   type: TXT
@@ -1066,6 +1074,10 @@ manage-key-workers:
     - ns-1932.awsdns-49.co.uk.
     - ns-62.awsdns-07.com.
     - ns-887.awsdns-46.net.
+manage.laa-online:
+  ttl: 300
+  type: CNAME
+  value: afd-endpoint-management-003-h6f6daejfsdngzdy.a02.azurefd.net
 manage.dev.laa-online:
   ttl: 300
   type: CNAME
@@ -1543,6 +1555,10 @@ refer-monitor-intervention:
     - ns-1460.awsdns-54.org.
     - ns-1824.awsdns-36.co.uk.
     - ns-423.awsdns-52.com.
+register.laa-online:
+  ttl: 300
+  type: CNAME
+  value: afd-endpoint-registration-003-h2ehcggkhag7aedb.a02.azurefd.net
 register.dev.laa-online:
   ttl: 300
   type: CNAME

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -163,22 +163,22 @@ _dmarc.recruitment:
   ttl: 300
   type: TXT
   value: v=DMARC1\;p=none\;rua=mailto:N4rHXmBVPY@dmarc.inboxmonster.com\;fo=0\;adkim=r\;aspf=r\;rf=afrf\;pct=100\;
-_dnsauth.manage.laa-online:
-  ttl: 300
-  type: TXT
-  value: _guqranwdfrzf1hrjj69pcrrh881x8dn
 _dnsauth.manage.dev.laa-online:
   ttl: 300
   type: TXT
   value: _c10if6cs0hjwzkve54i6zzaro6l1c0w
-_dnsauth.register.laa-online:
+_dnsauth.manage.laa-online:
   ttl: 300
   type: TXT
-  value: _7mxda2m7si2greeh8ddkgy6j1qugjm5
+  value: _guqranwdfrzf1hrjj69pcrrh881x8dn
 _dnsauth.register.dev.laa-online:
   ttl: 300
   type: TXT
   value: _ybr5jnrkxbizmhqfv5lddqosywc1r5k
+_dnsauth.register.laa-online:
+  ttl: 300
+  type: TXT
+  value: _7mxda2m7si2greeh8ddkgy6j1qugjm5
 _domainkey.recruitment:
   ttl: 300
   type: TXT
@@ -1074,14 +1074,14 @@ manage-key-workers:
     - ns-1932.awsdns-49.co.uk.
     - ns-62.awsdns-07.com.
     - ns-887.awsdns-46.net.
-manage.laa-online:
-  ttl: 300
-  type: CNAME
-  value: afd-endpoint-management-003-h6f6daejfsdngzdy.a02.azurefd.net
 manage.dev.laa-online:
   ttl: 300
   type: CNAME
   value: endpoint-admin-001-frcrh6hje3c7azcd.a01.azurefd.net
+manage.laa-online:
+  ttl: 300
+  type: CNAME
+  value: afd-endpoint-management-003-h6f6daejfsdngzdy.a02.azurefd.net
 management.analytical-platform:
   ttl: 300
   type: NS
@@ -1555,14 +1555,14 @@ refer-monitor-intervention:
     - ns-1460.awsdns-54.org.
     - ns-1824.awsdns-36.co.uk.
     - ns-423.awsdns-52.com.
-register.laa-online:
-  ttl: 300
-  type: CNAME
-  value: afd-endpoint-registration-003-h2ehcggkhag7aedb.a02.azurefd.net
 register.dev.laa-online:
   ttl: 300
   type: CNAME
   value: endpoint-registration-001-gng9gcaqakdbfve6.a01.azurefd.net
+register.laa-online:
+  ttl: 300
+  type: CNAME
+  value: afd-endpoint-registration-003-h2ehcggkhag7aedb.a02.azurefd.net
 request-for-personal-information:
   ttl: 3600
   type: NS


### PR DESCRIPTION
## 👀 Purpose

- This PR adds new laa-online subdomains.

## ♻️ What's changed

- Add TXT `_dnsauth.manage.laa-online.service.justice.gov.uk`
- Add TXT `_dnsauth.register.laa-online.service.justice.gov.uk`
- Add CNAME `manage.laa-online.service.justice.gov.uk`
- Add CNAME `register.laa-online.service.justice.gov.uk`