### PR TITLE
Remove MTA-STS related DNS records for sentencingcouncil.org.uk

### DIFF
--- a/hostedzones/sentencingcouncil.org.uk.yaml
+++ b/hostedzones/sentencingcouncil.org.uk.yaml
@@ -14,26 +14,6 @@ _asvdns-82dce4ea-c071-49e9-9164-f556aa6a2d32:
   ttl: 300
   type: TXT
   value: asvdns_c07dc387-d9a1-4d54-a531-27effdd26842
-_c118dcb76f6b712bb5fc5d2514f42d46.mta-sts:
-  ttl: 60
-  type: CNAME
-  value: _fe3ef0a59165845368320f32ba38ee8e.nhsllhhtvj.acm-validations.aws.
-_mta-sts:
-  ttl: 300
-  type: TXT
-  value: v=STSv1\; id=ece0c3ecb75bce54a99fd3cd9a3ca092
-_smtp._tls:
-  ttl: 300
-  type: TXT
-  value: v=TLSRPTv1\;rua=mailto:tls-rua@mailcheck.service.ncsc.gov.uk
-mta-sts:
-  ttl: 942942942
-  type: Route53Provider/ALIAS
-  value:
-    evaluate-target-health: true
-    hosted-zone-id: Z2FDTNDATAQYW2
-    name: dsabyr6tawzy4.cloudfront.net.
-    type: A
 www:
   ttl: 1800
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR bring DNS for `sentencingcouncil.org.uk` in line with what is actually in the `sentencingcouncil.org.uk` hostedzone following decommissioning of the related MTA-STS policy and infrastructure.

## ♻️ What's changed

- Delete CNAME `_c118dcb76f6b712bb5fc5d2514f42d46.mta-sts.sentencingcouncil.org.uk`
- Delete TXT `_mta-sts.sentencingcouncil.org.uk`
- Delete TXT `_smtp._tls.sentencingcouncil.org.uk`
- Delete Alias `mta-sts.sentencingcouncil.org.uk`

## 📝 Notes

- Related to [#91](https://github.com/ministryofjustice/mta-sts/pull/91)