### PR TITLE
Add A Record elinks.judiciary.uk

### DIFF
--- a/hostedzones/judiciary.uk.yaml
+++ b/hostedzones/judiciary.uk.yaml
@@ -195,6 +195,9 @@ elinks:
     values:
       - ms-domain-verification=9fbe3967-3f4d-4019-9e59-18cda4361c07
       - v=spf1 include:spf.protection.outlook.com -all
+  - ttl: 300
+    type: A
+    value: 172.166.178.94
 elinks-edge-email.elinks:
   ttl: 300
   type: MX


### PR DESCRIPTION
This PR adds a new A Record to route `elinks.judiciary.uk` to the same A Record as `prod.elinks.judiciary.uk`

