### PR TITLE
Update jac.intranet record

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -980,8 +980,12 @@ integrationtest:
     - ns-843.awsdns-41.net.
 jac.intranet:
   ttl: 300
-  type: CNAME
-  value: jacintranet.prod.wp.dsd.io
+  type: NS
+  values:
+    - ns-1427.awsdns-50.org
+    - ns-1953.awsdns-52.co.uk
+    - ns-227.awsdns-28.com
+    - ns-852.awsdns-42.net
 jacksapp-devs:
   ttl: 300
   type: NS


### PR DESCRIPTION
Request to modify the jac.intranet.service.justice.gov.uk record as it's moving over to the Cloud Platform.  This change points the DNS records to CP:

Old:

jac.intranet:
  ttl: 300
  type: CNAME
  value: jacintranet.prod.wp.dsd.io

New:

jac.intranet:
  ttl: 300
  type: NS
  values:
    - ns-1427.awsdns-50.org
    - ns-1953.awsdns-52.co.uk
    - ns-227.awsdns-28.com
    - ns-852.awsdns-42.net