### PR TITLE
Delegate ai.justice.gov.uk to Cloud Platform

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -468,6 +468,14 @@ agrvnzw2vg3wnycautqlvm6ojvgnoin7._domainkey:
   ttl: 300
   type: CNAME
   value: agrvnzw2vg3wnycautqlvm6ojvgnoin7.dkim.amazonses.com
+ai:
+  ttl: 300
+  type: NS
+  values:
+    - ns-1018.awsdns-63.net
+    - ns-1491.awsdns-58.org
+    - ns-1856.awsdns-40.co.uk
+    - ns-408.awsdns-51.com
 aka:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR delegates ai.justice.gov.uk to the Cloud Platform.

## ♻️ What's changed

- Add NS `ai.justice.gov.uk`