### PR TITLE
🔥 Remove Dangling Delgation to `sirius.publicguardian.gov.uk`

### DIFF
--- a/hostedzones/publicguardian.gov.uk.yaml
+++ b/hostedzones/publicguardian.gov.uk.yaml
@@ -98,14 +98,6 @@ selector2._domainkey:
   ttl: 300
   type: CNAME
   value: selector2-publicguardian-gov-uk._domainkey.justiceuk.onmicrosoft.com
-sirius:
-  ttl: 300
-  type: NS
-  values:
-    - ns-1083.awsdns-07.org.
-    - ns-1770.awsdns-29.co.uk.
-    - ns-486.awsdns-60.com.
-    - ns-870.awsdns-44.net.
 www:
   ttl: 942942942
   type: Route53Provider/ALIAS


### PR DESCRIPTION
## 👀 Purpose

- In relation to [MyNCSC Alert ](https://my.ncsc.gov.uk/org/e8ebe670-9dd1-4f57-8d20-e067932f46db/findings/domain/finding/a67df4b0-6038-4be4-996d-2c4f40d7760e?kd-ipp=10&kd-page=1)
- Raised in [Slack](https://mojdt.slack.com/archives/C01BUKJSZD4/p1749646059576959)

## ♻️ What's changed

- Removed dangling NS delegation for `sirius.publicguardian.gov.uk` to prevent domain hijacking