### PR TITLE
Add brevo subdomains to justice.gov.uk

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -29,6 +29,7 @@
       - google-site-verification=TCtRY9C86_qHXCh30w6fLkSQwGgLJG4uXzDorMrByVk
       - atlassian-domain-verification=vAjh0qsG/yJoMmOv6nM3A9a22B7Nc8acyzKreuqgTeiCjHkRxYoi6ZGQHNuU82Ua
       - openai-domain-verification=dv-K7YKE7fDeUHEZaXrnMLEVLOQ
+      - brevo-code:5df81568a8579db8c5271574de58f6bb
 2ma4ihuxerbnpfigizw76xlnnxmw6zdr._domainkey.magistrates-recruitment:
   ttl: 300
   type: CNAME
@@ -542,6 +543,14 @@ blogs:
     - ns-1678.awsdns-17.co.uk.
     - ns-393.awsdns-49.com.
     - ns-856.awsdns-43.net.
+brevo1._domainkey:
+  ttl: 300
+  type: CNAME
+  value: b1.justice-gov-uk.dkim.brevo.com
+brevo2._domainkey:
+  ttl: 300
+  type: CNAME
+  value: b2.justice-gov-uk.dkim.brevo.com
 bs7fgun22ztsnycpk3h3kz55apoqkmpw._domainkey.uat.ppud:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR adds a TXT domain validation record and DKIM email records to the justice.gov.uk domain, enabling it to be used for sending email from the MoJ Brevo account.

## ♻️ What's changed

- Update TXT `justice.gov.uk`
- Add CNAME `brevo1._domainkey.justice.gov.uk`
- Add CNAME `brevo2._domainkey.justice.gov.uk`