### PR TITLE
Add TXT record for GitHub Pages validation

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -249,6 +249,10 @@ _github-challenge-moj-analytical-services:
   ttl: 300
   type: TXT
   value: 610cab0fa8
+_github-pages-challenge-ministryofjustice.cloud-optimisation-and-accountability:
+  ttl: 300
+  type: TXT
+  value: 850a9bad548ca4fef49a6404f3df8c
 _h323cs._tcp.meet.video:
   ttl: 300
   type: SRV


### PR DESCRIPTION
We have added a custom domain for GitHub Pages - cloud-optimisation-and-accountability.justice.gov.uk.

This PR adds the verification challenge TXT record so that GitHub can confirm ownership.