### PR TITLE
Remove google from justice.gov.uk spf

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -24,7 +24,7 @@
       - atlassian-domain-verification=eZYa71sfUYC3GKWDAnR6IDBAD7m0PkEaKKOYkM2cjWj8or0XT0PwqvFpqTLtaNby
       - miro-verification=9f7733fab8b41c5d9bbbf63c043f10dcfec77dab
       - paloaltonetworks-site-verification=0b174a69a0bbb0078f1b18f4bac05c0bd943f50b2e279ea920cfe4e085ec4a48
-      - v=spf1 ip4:194.33.196.0/24 ip4:194.33.192.0/24 mx a:b.spf.service-now.com a:c.spf.service-now.com a:d.spf.service-now.com include:spf.protection.outlook.com include:_spf.google.com include:mail-relay.staff.service.justice.gov.uk include:amazonses.com -all
+      - v=spf1 ip4:194.33.196.0/24 ip4:194.33.192.0/24 mx a:b.spf.service-now.com a:c.spf.service-now.com a:d.spf.service-now.com include:spf.protection.outlook.com include:mail-relay.staff.service.justice.gov.uk include:amazonses.com -all
       - figma-domain-verification=497c3daab3cae3be9016c8e6c4a5cb0f7864326146415e1986018f7b84151fec-1733823729
       - google-site-verification=TCtRY9C86_qHXCh30w6fLkSQwGgLJG4uXzDorMrByVk
       - atlassian-domain-verification=vAjh0qsG/yJoMmOv6nM3A9a22B7Nc8acyzKreuqgTeiCjHkRxYoi6ZGQHNuU82Ua


### PR DESCRIPTION
## 👀 Purpose

- This PR removed the goolge related rule within the `justice.gov.uk` spf record. As we no longer use gmail with this domain it is no longer required.

## ♻️ What's changed

- Update  TXT `justice.gov.uk`