### PR TITLE
Remove CNAME user-guide.operations-engineering

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1834,10 +1834,6 @@ user-guide.laa-operations:
   ttl: 300
   type: CNAME
   value: ministryofjustice.github.io
-user-guide.operations-engineering:
-  ttl: 300
-  type: CNAME
-  value: ministryofjustice.github.io
 user-guide.staff-identity:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
This PR removes the CNAME for `user-guide.operations.engeering.service.justice.gov.uk`