### PR TITLE
Delete runbooks.operations-engineering CNAME

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1619,10 +1619,6 @@ review-criminal-legal-aid:
     - ns-1936.awsdns-50.co.uk.
     - ns-295.awsdns-36.com.
     - ns-604.awsdns-11.net.
-runbooks.operations-engineering:
-  ttl: 300
-  type: CNAME
-  value: ministryofjustice.github.io
 s1._domainkey.jac.intranet:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR removed the CNAME `runbooks.operations-engineering.service.justice.gov.uk`. Domain no longer in use.

## ♻️ What's changed

- Delete CNAME `runbooks.operations-engineering.service.justice.gov.uk`