### PR TITLE
Add TXT validation records for CDN and WAF public power pages sites

### DIFF
--- a/hostedzones/ima-citizensrights.org.uk.yaml
+++ b/hostedzones/ima-citizensrights.org.uk.yaml
@@ -68,6 +68,10 @@ _dmarc.newsletter:
   ttl: 300
   type: TXT
   value: v=DMARC1\;p=reject\;rua=mailto:dmarc-rua@dmarc.service.gov.uk,mailto:dmarc@digitaljustice.gov.uk,mailto:dmarcrua@e-shot.net\;
+_dnsauth.complaints:
+  ttl: 300
+  type: TXT
+  value: _23234f7o3ge6zgz39epe3263a9kulc1
 _github-challenge-ministryofjustice-org:
   ttl: 300
   type: TXT

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -179,6 +179,10 @@ _dnsauth.manage.laa-online:
   ttl: 300
   type: TXT
   value: _guqranwdfrzf1hrjj69pcrrh881x8dn
+_dnsauth.apply-for-hmpps-research:
+  ttl: 300
+  type: TXT
+  value: _ofnpi6l7fwvr2nln0f9ikpmmyjdsciz
 _dnsauth.register.dev.laa-online:
   ttl: 300
   type: TXT

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -171,6 +171,10 @@ _dmarc.recruitment:
   ttl: 300
   type: TXT
   value: v=DMARC1\;p=none\;rua=mailto:N4rHXmBVPY@dmarc.inboxmonster.com\;fo=0\;adkim=r\;aspf=r\;rf=afrf\;pct=100\;
+_dnsauth.apply-for-hmpps-research:
+  ttl: 300
+  type: TXT
+  value: _ofnpi6l7fwvr2nln0f9ikpmmyjdsciz
 _dnsauth.manage.dev.laa-online:
   ttl: 300
   type: TXT
@@ -179,10 +183,6 @@ _dnsauth.manage.laa-online:
   ttl: 300
   type: TXT
   value: _guqranwdfrzf1hrjj69pcrrh881x8dn
-_dnsauth.apply-for-hmpps-research:
-  ttl: 300
-  type: TXT
-  value: _ofnpi6l7fwvr2nln0f9ikpmmyjdsciz
 _dnsauth.register.dev.laa-online:
   ttl: 300
   type: TXT


### PR DESCRIPTION
## 👀 Purpose

This PR adds to TXT validation records for CDN and WAF public power pages sites

## ♻️ What's changed

- Add TXT `_dnsauth.complaints.ima-citizensrights.org.uk`
- Add TXT `_dnsauth.apply-for-hmpps-research.service.justice.gov.uk`