### PR TITLE
Add yjb CNAME records

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -414,10 +414,6 @@ advance-into-justice:
     - ns-1850.awsdns-39.co.uk.
     - ns-1059.awsdns-04.org.
     - ns-1016.awsdns-63.net.
-ah4lnpydpjs5l5z35kmxmnp4r4bkgg27._domainkey:
-  ttl: 300
-  type: CNAME
-  value: ah4lnpydpjs5l5z35kmxmnp4r4bkgg27.dkim.amazonses.com
 analytical-evidence-library:
   ttl: 300
   type: NS
@@ -519,10 +515,6 @@ c100:
     - ns-1553.awsdns-02.co.uk.
     - ns-374.awsdns-46.com.
     - ns-656.awsdns-18.net.
-ccdw2w6jvkr2vreletczhejsrnfecbbr._domainkey:
-  ttl: 300
-  type: CNAME
-  value: ccdw2w6jvkr2vreletczhejsrnfecbbr.dkim.amazonses.com
 ccms-ebs:
   type: NS
   values:
@@ -1034,10 +1026,6 @@ jury:
   ttl: 60
   type: CNAME
   value: jury-prototype.herokuapp.com
-k5l5ighhdj3e7e4wunbkxfspgg3nl4hv._domainkey:
-  ttl: 300
-  type: CNAME
-  value: k5l5ighhdj3e7e4wunbkxfspgg3nl4hv.dkim.amazonses.com
 laa-apex:
   ttl: 86400
   type: NS

--- a/hostedzones/yjb.gov.uk.yaml
+++ b/hostedzones/yjb.gov.uk.yaml
@@ -122,6 +122,10 @@ _smtp._tls.youthjusticepp:
   ttl: 300
   type: TXT
   value: v=TLSRPTv1\;rua=mailto:tls-rua@mailcheck.service.ncsc.gov.uk
+ah4lnpydpjs5l5z35kmxmnp4r4bkgg27._domainkey:
+  ttl: 300
+  type: CNAME
+  value: ah4lnpydpjs5l5z35kmxmnp4r4bkgg27.dkim.amazonses.com
 anugym6qhqpgzbegpxrp26htx36nixrm._domainkey:
   ttl: 300
   type: CNAME
@@ -133,6 +137,10 @@ ba57tyzq6qama5pndafilxh57qhain5m._domainkey:
   ttl: 300
   type: CNAME
   value: ba57tyzq6qama5pndafilxh57qhain5m.dkim.amazonses.com
+ccdw2w6jvkr2vreletczhejsrnfecbbr._domainkey:
+  ttl: 300
+  type: CNAME
+  value: ccdw2w6jvkr2vreletczhejsrnfecbbr.dkim.amazonses.com
 coo6soxcnaluiv3zpqvxtfdzo5wkoyup._domainkey:
   ttl: 300
   type: CNAME
@@ -172,6 +180,10 @@ juniper-smtp:
   - ttl: 300
     type: TXT
     value: v=spf1 include:amazonses.com -all
+k5l5ighhdj3e7e4wunbkxfspgg3nl4hv._domainkey:
+  ttl: 300
+  type: CNAME
+  value: k5l5ighhdj3e7e4wunbkxfspgg3nl4hv.dkim.amazonses.com
 kr2ub2cm6agxllr4lc4wjibgsvu2ph44._domainkey:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
Request to add the following CNAME records to yjb.gov.uk:


 - CNAME | k5l5ighhdj3e7e4wunbkxfspgg3nl4hv._domainkey.yjb.gov.uk | k5l5ighhdj3e7e4wunbkxfspgg3nl4hv.dkim.amazonses.com
 - CNAME | ah4lnpydpjs5l5z35kmxmnp4r4bkgg27._domainkey.yjb.gov.uk | ah4lnpydpjs5l5z35kmxmnp4r4bkgg27.dkim.amazonses.com
 - CNAME | ccdw2w6jvkr2vreletczhejsrnfecbbr._domainkey.yjb.gov.uk | ccdw2w6jvkr2vreletczhejsrnfecbbr.dkim.amazonses.com
