### PR TITLE
chore: Add A record for langfuse sandbox app

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -1293,6 +1293,10 @@ llrs.nle:
   ttl: 60
   type: A
   value: 195.59.75.138
+lng.ai:
+  ttl: 3600
+  type: A
+  value: 108.142.104.36
 locateaprison:
   ttl: 600
   type: A


### PR DESCRIPTION
LangFuse is a tracing solution specific to agentic AI applications. The domain delegation rule allow us to self-host the application. 