### PR TITLE
Remove laa-online DNS records

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -167,6 +167,10 @@ _domainkey.recruitment:
   ttl: 300
   type: TXT
   value: t=y\; o=~\;
+_dnsauth.apply-for-hmpps-research:
+  ttl: 300
+  type: TXT
+  value: _ofnpi6l7fwvr2nln0f9ikpmmyjdsciz
 _e423c56d23dc0dce73d7af3276cfd0e6.manage-external-funded-offender-provision:
   ttl: 300
   type: CNAME

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -163,26 +163,6 @@ _dmarc.recruitment:
   ttl: 300
   type: TXT
   value: v=DMARC1\;p=none\;rua=mailto:N4rHXmBVPY@dmarc.inboxmonster.com\;fo=0\;adkim=r\;aspf=r\;rf=afrf\;pct=100\;
-_dnsauth.apply-for-hmpps-research:
-  ttl: 300
-  type: TXT
-  value: _ofnpi6l7fwvr2nln0f9ikpmmyjdsciz
-_dnsauth.manage.dev.laa-online:
-  ttl: 300
-  type: TXT
-  value: _c10if6cs0hjwzkve54i6zzaro6l1c0w
-_dnsauth.manage.laa-online:
-  ttl: 300
-  type: TXT
-  value: _guqranwdfrzf1hrjj69pcrrh881x8dn
-_dnsauth.register.dev.laa-online:
-  ttl: 300
-  type: TXT
-  value: _ybr5jnrkxbizmhqfv5lddqosywc1r5k
-_dnsauth.register.laa-online:
-  ttl: 300
-  type: TXT
-  value: _7mxda2m7si2greeh8ddkgy6j1qugjm5
 _domainkey.recruitment:
   ttl: 300
   type: TXT
@@ -1090,14 +1070,6 @@ manage-key-workers:
     - ns-1932.awsdns-49.co.uk.
     - ns-62.awsdns-07.com.
     - ns-887.awsdns-46.net.
-manage.dev.laa-online:
-  ttl: 300
-  type: CNAME
-  value: endpoint-admin-001-frcrh6hje3c7azcd.a01.azurefd.net
-manage.laa-online:
-  ttl: 300
-  type: CNAME
-  value: afd-endpoint-management-003-h6f6daejfsdngzdy.a02.azurefd.net
 management.analytical-platform:
   ttl: 300
   type: NS
@@ -1571,14 +1543,6 @@ refer-monitor-intervention:
     - ns-1460.awsdns-54.org.
     - ns-1824.awsdns-36.co.uk.
     - ns-423.awsdns-52.com.
-register.dev.laa-online:
-  ttl: 300
-  type: CNAME
-  value: endpoint-registration-001-gng9gcaqakdbfve6.a01.azurefd.net
-register.laa-online:
-  ttl: 300
-  type: CNAME
-  value: afd-endpoint-registration-003-h2ehcggkhag7aedb.a02.azurefd.net
 request-for-personal-information:
   ttl: 3600
   type: NS

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -163,14 +163,14 @@ _dmarc.recruitment:
   ttl: 300
   type: TXT
   value: v=DMARC1\;p=none\;rua=mailto:N4rHXmBVPY@dmarc.inboxmonster.com\;fo=0\;adkim=r\;aspf=r\;rf=afrf\;pct=100\;
-_domainkey.recruitment:
-  ttl: 300
-  type: TXT
-  value: t=y\; o=~\;
 _dnsauth.apply-for-hmpps-research:
   ttl: 300
   type: TXT
   value: _ofnpi6l7fwvr2nln0f9ikpmmyjdsciz
+_domainkey.recruitment:
+  ttl: 300
+  type: TXT
+  value: t=y\; o=~\;
 _e423c56d23dc0dce73d7af3276cfd0e6.manage-external-funded-offender-provision:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR removes DNS records relating to `laa-online.service.justice.gov.uk` which are no longer required. Services are decommissioned.

## ♻️ What's changed

- Delete TXT `_dnsauth.manage.dev.laa-online.service.justice.gov.uk`
- Delete TXT `_dnsauth.manage.laa-online.service.justice.gov.uk`
- Delete TXT `_dnsauth.register.dev.laa-online.service.justice.gov.uk`
- Delete TXT `_dnsauth.register.laa-online.service.justice.gov.uk`
- Delete CNAME `manage.dev.laa-online.service.justice.gov.uk`
- Delete CNAME `manage.laa-online.service.justice.gov.uk`
- Delete CNAME `register.dev.laa-online.service.justice.gov.uk`
- Delete CNAME `register.laa-online.service.justice.gov.uk`