### PR TITLE
fix: Switch to NS record as required for SSL with Let's Encrypt

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -1220,7 +1220,7 @@ k3._domainkey:
 langfuse-ai:
   ttl: 3600
   type: NS
-  value: 
+  value:
     - ns1-06.azure-dns.com.
     - ns2-06.azure-dns.net.
     - ns3-06.azure-dns.org.

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -1219,8 +1219,12 @@ k3._domainkey:
   value: dkim3.mcsv.net
 langfuse-ai:
   ttl: 3600
-  type: A
-  value: 108.141.186.61
+  type: NS
+  value: 
+    - ns1-06.azure-dns.com.
+    - ns2-06.azure-dns.net.
+    - ns3-06.azure-dns.org.
+    - ns4-06.azure-dns.info.
 lawcommission:
   ttl: 600
   type: A


### PR DESCRIPTION
I've just read the guidance on certification here: https://security-guidance.service.justice.gov.uk/automated-certificate-renewal/#automated-certificate-renewal

For this to work, I'll need to set an NS record instead.