### PR TITLE
chore: Verify domain for Azure Email

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -1218,15 +1218,17 @@ k3._domainkey:
   type: CNAME
   value: dkim3.mcsv.net
 langfuse-ai:
-  - type: NS
+  - name: langfuse-ai.justice.gov.uk
     ttl: 3600
+    type: NS
     value:
       - ns1-06.azure-dns.com.
       - ns2-06.azure-dns.net.
       - ns3-06.azure-dns.org.
       - ns4-06.azure-dns.info.
-  - type: TXT
+  - name: langfuse-ai.justice.gov.uk
     ttl: 3600
+    type: TXT
     value: ms-domain-verification=c8a6f693-007d-4cc6-bfa4-f6c2949da4f3
 lawcommission:
   ttl: 600


### PR DESCRIPTION
Setting up SMTP for langfuse organisation member onboarding - not intended for public use and limited to sandbox azure scope. Colleagues receive invite initiated by LangFuse org admin. Access to org is behind SSO.