### PR TITLE
Delete dangling cjscp.justice.gov.uk subdomains

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -624,17 +624,6 @@ civilmediation:
     hosted-zone-id: ZHURV8PSTC4K8
     name: dualstack.civil-mediation-load-377727311.eu-west-2.elb.amazonaws.com.
     type: A
-cjscp:
-  - ttl: 600
-    type: MX
-    values:
-      - exchange: mx00003.skyscapecloud.com.
-        preference: 10
-      - exchange: mx00004.skyscapecloud.com.
-        preference: 10
-  - ttl: 600
-    type: TXT
-    value: v=spf1 mx -all
 cjsm:
   ttl: 900
   type: NS


### PR DESCRIPTION
## 👀 Purpose

- This PR removes dangling DNS records for `cjscp.justice.gov.uk`. Removal of the records mitigates security risk. 

## ♻️ What's changed

- Delete MX `cjscp.justice.gov.uk`
- Delete TXT `cjscp.justice.gov.uk`