### PR TITLE
Update add azure portal DNS

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -167,6 +167,14 @@ _dnsauth.apply-for-hmpps-research:
   ttl: 300
   type: TXT
   value: _ofnpi6l7fwvr2nln0f9ikpmmyjdsciz
+_dnsauth.portal.dev.external-identity:
+  ttl: 300
+  type: TXT
+  value: _i9hty6rziza05xmhcbzhg1gzr25uq0o
+_dnsauth.portal-laa.dev.external-identity:
+  ttl: 300
+  type: TXT
+  value: _uet60uwc7jz3ql5l2bec3o1g2qw7jf9
 _domainkey.recruitment:
   ttl: 300
   type: TXT
@@ -1312,6 +1320,14 @@ planetfm:
     - ns-1749.awsdns-26.co.uk
     - ns-219.awsdns-27.com
     - ns-609.awsdns-12.net
+portal.dev.external-identity:
+  ttl: 300
+  type: CNAME
+  value: afd-endpoint-eucs-entra-ext-activation-001-bucxcyfdhzfea5ap.a01.azurefd.net
+portal-laa.dev.external-identity:
+  ttl: 300
+  type: CNAME
+  value: afd-endpoint-eucs-entra-ext-activation-001-bucxcyfdhzfea5ap.a01.azurefd.net
 pqzo3wwgkdgsl3s5fmad52yftinv4hvm._domainkey:
   ttl: 1800
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR adds some TXT and CNAME records for new domains being set up with Azure.

## ♻️ What's changed

- Add TXT `_dnsauth.portal-laa.dev.external-identity.service.justice.gov.uk`
- Add TXT `_dnsauth.portal.dev.external-identity.service.justice.gov.uk`
- Add CNAME `portal-laa.dev.external-identity.service.justice.gov.uk`
- Add CNAME `portal.dev.external-identity.service.justice.gov.uk`