### PR TITLE
Reduce ttl prior to migrations

### DIFF
--- a/hostedzones/sentencingcouncil.org.uk.yaml
+++ b/hostedzones/sentencingcouncil.org.uk.yaml
@@ -1,6 +1,6 @@
 ---
 '':
-  - ttl: 600
+  - ttl: 300
     type: A
     value: 35.177.235.232
   - ttl: 172800
@@ -15,6 +15,6 @@ _asvdns-82dce4ea-c071-49e9-9164-f556aa6a2d32:
   type: TXT
   value: asvdns_c07dc387-d9a1-4d54-a531-27effdd26842
 www:
-  ttl: 1800
+  ttl: 300
   type: CNAME
   value: sentencing.live.bangdynamics.com.

--- a/hostedzones/youbethejudge.org.uk.yaml
+++ b/hostedzones/youbethejudge.org.uk.yaml
@@ -7,11 +7,11 @@
       - ns-573.awsdns-07.net.
       - ns-1129.awsdns-13.org.
       - ns-1793.awsdns-32.co.uk.
-  - ttl: 3600
+  - ttl: 300
     type: A
     value: 35.214.53.226
 _17f1a5ff0645fabb456800298990b973:
-    ttl: 86400
+    ttl: 120
     type: NS
     values:
       - 567.dns-approval.sslmate.com.
@@ -26,6 +26,6 @@ _b5ac0b5abd9fcb994ba26c5369478a23.www:
     values:
       - 567.dns-approval.sslmate.com.
 www:
-  ttl: 43200
+  ttl: 300
   type: CNAME
   value: youbethejudge.org.uk.


### PR DESCRIPTION
## 👀 Purpose

- This PR reduces the ttls on a number of `sentencingcouncil.org.uk` and `youbethejudge.org.uk` subdomains. We are reducing ttls in advance of migration activities to improve cutover time.

## ♻️ What's changed

- Multiple ttls