### PR TITLE
Add ideas.justice.gov.uk

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -1127,6 +1127,10 @@ hmpps-az-gw1:
     - ns2-06.azure-dns.net.
     - ns3-06.azure-dns.org.
     - ns4-06.azure-dns.info.
+ideas:
+  ttl: 300
+  type: CNAME
+  value: da-moj.delib.net
 immigrationappealsonline:
   ttl: 600
   type: NS


### PR DESCRIPTION
## 👀 Purpose

- This PR adds a new subdomain `ideas.justice.gov.uk`. Required for new service.

## ♻️ What's changed

- Add CNAME `ideas.justice.gov.uk`