### PR TITLE
Update mappa.justice.gov.uk

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -1339,17 +1339,9 @@ mal03:
   type: A
   value: 195.59.62.70
 mappa:
-  - ttl: 600
-    type: A
-    value: 31.25.189.126
-  - ttl: 600
-    type: MX
-    value:
-      exchange: mail.hosting.inovem.com.
-      preference: 5
-  - ttl: 300
-    type: TXT
-    value: v=spf1 ~all
+  - ttl: 3600
+    type: CNAME
+    value: mappa-justice-gov-uk.map.kahootz.com.
 markuppp:
   ttl: 600
   type: A


### PR DESCRIPTION
## 👀 Purpose

- This PR makes changes to `mappa.justice.gov.uk` subdomains as a result of upcoming changes to Kahootz underlying infrastructure improvements.

## ♻️ What's changed

- Add CNAME `mappa.justice.gov.uk`
- Delete ARECORD `mappa.justice.gov.uk`
- Delete MX `mappa.justice.gov.uk`
- Delete TXT `mappa.justice.gov.uk`