### PR TITLE
Add certificate validation CNAMES

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -360,7 +360,7 @@ _lguoa2m4p2jicwdnc3k4evg3cnqleao.playback.video.service:
 _lguoa2m4p2jicwdnc3k4evg3cnqleao.www.playback.video.service:
   ttl: 300
   type: CNAME
-  value:
+  value: dcv.digicert.com.
 _mta-sts:
   ttl: 300
   type: TXT


### PR DESCRIPTION
Certificate validation is required for the renewal of the following certificate:

 -  playback.video.service.justice.gov.uk

This certificate has multiple SAN's so the following CNAMES need to be added:

- playback.video.service.justice.gov.uk
- playback1.video.service.justice.gov.uk
- playback2.video.service.justice.gov.uk
- playback3.video.service.justice.gov.uk
- playback4.video.service.justice.gov.uk
- playback5.video.service.justice.gov.uk
- playback6.video.service.justice.gov.uk
- www.playback.video.service.justice.gov.uk