### PR TITLE
Add portal.test and portal-laa.test subdomains

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -171,10 +171,18 @@ _dnsauth.portal-laa.dev.external-identity:
   ttl: 300
   type: TXT
   value: _uet60uwc7jz3ql5l2bec3o1g2qw7jf9
+_dnsauth.portal-laa.test.external-identity:
+  ttl: 300
+  type: CNAME
+  value: _95lxmd5t6oy612zrago8xb52z01fqti
 _dnsauth.portal.dev.external-identity:
   ttl: 300
   type: TXT
   value: _i9hty6rziza05xmhcbzhg1gzr25uq0o
+_dnsauth.portal.test.external-identity:
+  ttl: 300
+  type: TXT
+  value: _pukihwujxune214qc6iv936j8nol3qr
 _domainkey.recruitment:
   ttl: 300
   type: TXT
@@ -1324,10 +1332,18 @@ portal-laa.dev.external-identity:
   ttl: 300
   type: CNAME
   value: afd-endpoint-eucs-entra-ext-activation-001-bucxcyfdhzfea5ap.a01.azurefd.net
+portal-laa.test.external-identity:
+  ttl: 300
+  type: CNAME
+  value: afd-endpoint-eucs-entra-ext-activation-002-cygyfsc2gxbecjhf.a01.azurefd.net
 portal.dev.external-identity:
   ttl: 300
   type: CNAME
   value: afd-endpoint-eucs-entra-ext-activation-001-bucxcyfdhzfea5ap.a01.azurefd.net
+portal.test.external-identity:
+  ttl: 300
+  type: CNAME
+  value: afd-endpoint-eucs-entra-ext-activation-002-cygyfsc2gxbecjhf.a01.azurefd.net
 pqzo3wwgkdgsl3s5fmad52yftinv4hvm._domainkey:
   ttl: 1800
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR adds new subdomains for validation of `portal.test` and `porrtal-laa.test` for with the external identity service.

## ♻️ What's changed

- Add CNAME `portal.test.external-identity.service.justice.gov.uk`
- Add TXT `_dnsauth.portal.test.external-identity.service.justice.gov.uk`
- Add CNAME `portal-laa.test.external-identity.service.justice.gov.uk`
- Add TXT `_dnsauth.portal-laa.test.external-identity.service.justice.gov.uk`