### PR TITLE
Reinstate video.service.justice.gov.uk cert subdomains

### DIFF
--- a/hostedzones/video.service.justice.gov.uk.yaml
+++ b/hostedzones/video.service.justice.gov.uk.yaml
@@ -7,6 +7,38 @@
     - ns-1867.awsdns-41.co.uk.
     - ns-52.awsdns-06.com.
     - ns-936.awsdns-53.net.
+_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback1:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback2:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback3:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback4:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback5:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback6:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_lguoa2m4p2jicwdnc3k4evg3cnqleao.www.playback:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 playback:
   ttl: 60
   type: A


### PR DESCRIPTION
## 👀 Purpose

- This PR reverts changes from #519. Change removed too many records in one go so pipeline is currently broken. Reinstating these records will fix the broken pipeline.

The DNS records will need to be removed in smaller batches later.

## ♻️ What's changed

- Reverts #519 