### PR TITLE
Add CNAME verification for cert regen

### DIFF
--- a/hostedzones/video.service.justice.gov.uk.yaml
+++ b/hostedzones/video.service.justice.gov.uk.yaml
@@ -7,6 +7,38 @@
     - ns-1867.awsdns-41.co.uk.
     - ns-52.awsdns-06.com.
     - ns-936.awsdns-53.net.
+_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback1:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback2:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback3:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback4:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback5:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback6:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_lguoa2m4p2jicwdnc3k4evg3cnqleao.www.playback:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 playback:
   ttl: 60
   type: A


### PR DESCRIPTION
Certificate playback.video.service.justice.gov.uk has been regenerated and requires verification.

Added the following CNAMES back to video.service.justice.gov.uk hosted zone:

- playback
- playback1
- playback2
- playback3
- playback4
- playback5
- playback6
- www.playback
