### PR TITLE
Update CNAME verification keys

### DIFF
--- a/hostedzones/video.service.justice.gov.uk.yaml
+++ b/hostedzones/video.service.justice.gov.uk.yaml
@@ -7,35 +7,35 @@
     - ns-1867.awsdns-41.co.uk.
     - ns-52.awsdns-06.com.
     - ns-936.awsdns-53.net.
-_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback:
+_h1bwzd6mwjxszqldanw0t604v6hggw1.playback:
   ttl: 300
   type: CNAME
   value: dcv.digicert.com.
-_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback1:
+_h1bwzd6mwjxszqldanw0t604v6hggw1.playback1:
   ttl: 300
   type: CNAME
   value: dcv.digicert.com.
-_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback2:
+_h1bwzd6mwjxszqldanw0t604v6hggw1.playback2:
   ttl: 300
   type: CNAME
   value: dcv.digicert.com.
-_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback3:
+_h1bwzd6mwjxszqldanw0t604v6hggw1.playback3:
   ttl: 300
   type: CNAME
   value: dcv.digicert.com.
-_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback4:
+_h1bwzd6mwjxszqldanw0t604v6hggw1.playback4:
   ttl: 300
   type: CNAME
   value: dcv.digicert.com.
-_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback5:
+_h1bwzd6mwjxszqldanw0t604v6hggw1.playback5:
   ttl: 300
   type: CNAME
   value: dcv.digicert.com.
-_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback6:
+_h1bwzd6mwjxszqldanw0t604v6hggw1.playback6:
   ttl: 300
   type: CNAME
   value: dcv.digicert.com.
-_lguoa2m4p2jicwdnc3k4evg3cnqleao.www.playback:
+_h1bwzd6mwjxszqldanw0t604v6hggw1.www.playback:
   ttl: 300
   type: CNAME
   value: dcv.digicert.com.


### PR DESCRIPTION
Mistakenly added the incorrect certificate verification CNAME keys to video.service.justice.gov.uk.

This PR updates the keys with correct names.