### PR TITLE
Add CNAME certificate regen verification

### DIFF
--- a/hostedzones/video.service.justice.gov.uk.yaml
+++ b/hostedzones/video.service.justice.gov.uk.yaml
@@ -39,6 +39,38 @@ _lguoa2m4p2jicwdnc3k4evg3cnqleao.www.playback:
   ttl: 300
   type: CNAME
   value: dcv.digicert.com.
+_h1bwzd6mwjxszqldanw0t604v6hggw1.playback:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_h1bwzd6mwjxszqldanw0t604v6hggw1.playback1:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_h1bwzd6mwjxszqldanw0t604v6hggw1.playback2:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_h1bwzd6mwjxszqldanw0t604v6hggw1.playback3:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_h1bwzd6mwjxszqldanw0t604v6hggw1.playback4:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_h1bwzd6mwjxszqldanw0t604v6hggw1.playback5:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_h1bwzd6mwjxszqldanw0t604v6hggw1.playback6:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_h1bwzd6mwjxszqldanw0t604v6hggw1.www.playback:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 playback:
   ttl: 60
   type: A


### PR DESCRIPTION
playback.video.service.justice.gov.uk has been regenerated.  This PR adds the updated CNAME verification records to the hosted zone.

Will clear out all the playback.video.service.justice.gov.uk verification CNAMEs once this PR is merged and the certificate has validated as there will be 2 sets.  This is due to an issue with OctoDNS - too may changes have been made to the records and it is not allowing them to run. 