### PR TITLE
Delete digicert validation records

### DIFF
--- a/hostedzones/video.service.justice.gov.uk.yaml
+++ b/hostedzones/video.service.justice.gov.uk.yaml
@@ -39,38 +39,6 @@ _h1bwzd6mwjxszqldanw0t604v6hggw1.www.playback:
   ttl: 300
   type: CNAME
   value: dcv.digicert.com.
-_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
-_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback1:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
-_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback2:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
-_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback3:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
-_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback4:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
-_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback5:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
-_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback6:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
-_lguoa2m4p2jicwdnc3k4evg3cnqleao.www.playback:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
 playback:
   ttl: 60
   type: A


### PR DESCRIPTION
## 👀 Purpose

- The PR removes cert validation records that are no longer required.

## ♻️ What's changed

- Delete CNAME `_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback.video.service.justice.gov.uk`
- Delete CNAME `_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback1.video.service.justice.gov.uk`
- Delete CNAME `_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback2.video.service.justice.gov.uk`
- Delete CNAME `_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback3.video.service.justice.gov.uk`
- Delete CNAME `_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback4.video.service.justice.gov.uk`
- Delete CNAME `_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback5.video.service.justice.gov.uk`
- Delete CNAME `_lguoa2m4p2jicwdnc3k4evg3cnqleao.playback6.video.service.justice.gov.uk`
- Delete CNAME `_lguoa2m4p2jicwdnc3k4evg3cnqleao.www.playback.video.service.justice.gov.uk`