### PR TITLE
Delete the next batch of digicert validation records

### DIFF
--- a/hostedzones/video.service.justice.gov.uk.yaml
+++ b/hostedzones/video.service.justice.gov.uk.yaml
@@ -7,18 +7,6 @@
     - ns-1867.awsdns-41.co.uk.
     - ns-52.awsdns-06.com.
     - ns-936.awsdns-53.net.
-_h1bwzd6mwjxszqldanw0t604v6hggw1.playback4:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
-_h1bwzd6mwjxszqldanw0t604v6hggw1.playback5:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
-_h1bwzd6mwjxszqldanw0t604v6hggw1.playback6:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
 _h1bwzd6mwjxszqldanw0t604v6hggw1.www.playback:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
Deletes the first 3 records of CNAME validation records for playback.video.service.justice.gov.uk