### PR TITLE
Delete final digicert validation record

### DIFF
--- a/hostedzones/video.service.justice.gov.uk.yaml
+++ b/hostedzones/video.service.justice.gov.uk.yaml
@@ -7,10 +7,6 @@
     - ns-1867.awsdns-41.co.uk.
     - ns-52.awsdns-06.com.
     - ns-936.awsdns-53.net.
-_h1bwzd6mwjxszqldanw0t604v6hggw1.www.playback:
-  ttl: 300
-  type: CNAME
-  value: dcv.digicert.com.
 playback:
   ttl: 60
   type: A


### PR DESCRIPTION
Deletes final CNAME validation records for playback.video.service.justice.gov.uk