### PR TITLE
Add NS records for laa-benefit-checker

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1022,6 +1022,14 @@ laa-apex:
     - ns-484.awsdns-60.com.
     - ns-1921.awsdns-48.co.uk.
     - ns-1158.awsdns-16.org.
+laa-benefit-checker:
+  ttl: 300
+  type: NS
+  values: 
+    - ns-1494.awsdns-58.org
+    - ns-1921.awsdns-48.co.uk
+    - ns-64.awsdns-08.com
+    - ns-916.awsdns-50.net
 laa-crime:
   ttl: 300
   type: TXT

--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1025,7 +1025,7 @@ laa-apex:
 laa-benefit-checker:
   ttl: 300
   type: NS
-  values: 
+  values:
     - ns-1494.awsdns-58.org
     - ns-1921.awsdns-48.co.uk
     - ns-64.awsdns-08.com


### PR DESCRIPTION
Request to add NS records for the delegation of a Route53 hosted zone in PROD for:

 - laa-benefit-checker.service.justice.gov.uk