### PR TITLE
Remove uat.laa-benefit-checker.service.justice.gov.uk delegation

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1854,14 +1854,6 @@ uat.crown-court-remuneration:
   ttl: 300
   type: CNAME
   value: d3gnf84r7r46aa.cloudfront.net
-uat.laa-benefit-checker:
-  ttl: 300
-  type: NS
-  values:
-    - ns-1064.awsdns-05.org
-    - ns-1656.awsdns-15.co.uk
-    - ns-405.awsdns-50.com
-    - ns-742.awsdns-28.net
 uat.list-assist:
   ttl: 300
   type: A


### PR DESCRIPTION
Remove `uat.laa-benefit-checker.service.justice.gov.uk` delegation as no longer required. 