### PR TITLE
Add libra-prod.apps.justice.gov.uk cert validation records

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -457,6 +457,14 @@ _smtp._tls.mappa:
   ttl: 300
   type: TXT
   value: v=TLSRPTv1\;rua=mailto:tls-rua@mailcheck.service.ncsc.gov.uk
+_suj7voa0vkyiutt1cyfoq5flz16xdcx.libra-prod.apps:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
+_suj7voa0vkyiutt1cyfoq5flz16xdcx.www.libra-prod.apps:
+  ttl: 300
+  type: CNAME
+  value: dcv.digicert.com.
 adcourt._domainkey.administrativecourtoffice:
   ttl: 300
   type: TXT


### PR DESCRIPTION
## 👀 Purpose

- This PR adds cert validation CNAME for renewed certs.

## ♻️ What's changed

- Add `_suj7voa0vkyiutt1cyfoq5flz16xdcx.libra-prod.apps.justice.gov.uk`
- Add `_suj7voa0vkyiutt1cyfoq5flz16xdcx.www.libra-prod.apps.justice.gov.uk`