### PR TITLE
🆙 Update SPF Record for `recruitment.service.justice.gov.uk`

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1586,7 +1586,7 @@ recruitment:
         preference: 10
   - ttl: 300
     type: TXT
-    value: v=spf1 include:spf.dotmailer.com -all
+    value: v=spf1 include:spf.dotmailer.com include:sendgrid.net -all
 refer-monitor-intervention:
   ttl: 300
   type: NS


### PR DESCRIPTION
## 👀 Purpose

- In relation to the email to the domain's inbox titled `Third party emails for Magistrate Candidates - JUNK`
- Update SPF record for `recruitment.service.justice.gov.uk` to include additional sendgrid.net sender, to _hopefully_ stop end users missing emails due to email clients marking them as junk

## ♻️ What's changed

- Update SPF Record for `recruitment.service.justice.gov.uk` to include `sendgrid.net` i.e. `include:sendgrid.net`