### PR TITLE
Delete jury.service.justice.gov.uk

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1010,10 +1010,6 @@ judicialoffice.intranet:
   ttl: 300
   type: CNAME
   value: jointranet.prod.wp.dsd.io
-jury:
-  ttl: 60
-  type: CNAME
-  value: jury-prototype.herokuapp.com
 laa-apex:
   ttl: 86400
   type: NS


### PR DESCRIPTION
Removes unused CNAME. Remediate risk of takeover