### PR TITLE
Add JAMF verification record for justice.gov.uk

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -30,6 +30,7 @@
       - atlassian-domain-verification=vAjh0qsG/yJoMmOv6nM3A9a22B7Nc8acyzKreuqgTeiCjHkRxYoi6ZGQHNuU82Ua
       - openai-domain-verification=dv-K7YKE7fDeUHEZaXrnMLEVLOQ
       - brevo-code:5df81568a8579db8c5271574de58f6bb
+      - jamf-site-verification=7hKH_tP5JKaZNA5AhAn2kA
 2ma4ihuxerbnpfigizw76xlnnxmw6zdr._domainkey.magistrates-recruitment:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
## 👀 Purpose

- This PR adds JAMF verification record for `justice.gov.uk`. Required for SSO for JAMF account to enable some critical features for managing Mac devices.

## ♻️ What's changed

- Update TXT `justice.gov.uk`