### PR TITLE
Remove duplicate SPF record

### DIFF
--- a/hostedzones/judicialappointments.gov.uk.yaml
+++ b/hostedzones/judicialappointments.gov.uk.yaml
@@ -14,10 +14,6 @@
       - ns-1621.awsdns-10.co.uk.
       - ns-188.awsdns-23.com.
       - ns-798.awsdns-35.net.
-  - ttl: 300
-    type: SPF
-    value: v=spf1 ip4:194.33.196.8/32 ip4:194.33.192.8/32  include:spf.protection.outlook.com
-      -all
   - type: TXT
     values:
       - MS=ms55245335


### PR DESCRIPTION
This PR removes a duplicate `SPF` record that is already present in the `TXT` record for `judicialappointments.gov.uk`.

Removing to reduce complexity.