### PR TITLE
Add tech-radar.justice.gov.uk

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -2030,6 +2030,10 @@ tbm6oiqakgjs7zp7ufy2w3dagkonfrry._domainkey.cshrcaseworkcma:
   ttl: 300
   type: CNAME
   value: tbm6oiqakgjs7zp7ufy2w3dagkonfrry.dkim.amazonses.com
+tech-radar:
+  ttl: 300
+  type: CNAME
+  value: ministryofjustice.github.io
 test:
   ttl: 600
   type: NS


### PR DESCRIPTION
This pull request adds a new CNAME record for the `tech-radar` subdomain. This change enables the `tech-radar` subdomain to point to `ministryofjustice.github.io` for the pages site.

DNS configuration update:

* Added a CNAME record for the `tech-radar` subdomain, pointing it to `ministryofjustice.github.io` in the `hostedzones/justice.gov.uk.yaml` file.