### PR TITLE
Add email tenant DNS records for pay-by-account.justice.gov.uk

### DIFF
--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -1673,7 +1673,9 @@ optic:
 pay-by-account:
   - ttl: 3600
     type: MX
-    value: paybyaccount-justice-gov-uk0ie.mail.protection.outlook.com.
+    value: 
+      exchange: paybyaccount-justice-gov-uk0ie.mail.protection.outlook.com.
+      preference: 0
   - ttl: 3600
     type: TXT
     value: v=spf1 include:spf.protection.outlook.com -all

--- a/hostedzones/justice.gov.uk.yaml
+++ b/hostedzones/justice.gov.uk.yaml
@@ -661,6 +661,10 @@ autodiscover.fax:
 autodiscover.official:
   type: CNAME
   value: autodiscover.outlook.com
+autodiscover.pay-by-account:
+  ttl: 3600
+  type: CNAME
+  value: autodiscover.outlook.com.
 avature-ext._domainkey:
   ttl: 300
   type: TXT
@@ -1058,6 +1062,10 @@ enterpriseenrollment.cshrcasework:
 enterpriseenrollment.official:
   type: CNAME
   value: enterpriseenrollment.manage.microsoft.com
+enterpriseenrollment.pay-by-account:
+  ttl: 3600
+  type: CNAME
+  value: enterpriseenrollment-s.manage.microsoft.com.
 enterpriseregistration:
   ttl: 600
   type: CNAME
@@ -1076,6 +1084,10 @@ enterpriseregistration.cshrcasework:
 enterpriseregistration.official:
   type: CNAME
   value: enterpriseregistration.windows.net
+enterpriseregistration.pay-by-account:
+  ttl: 3600
+  type: CNAME
+  value: enterpriseregistration.windows.net.
 erupload:
   ttl: 600
   type: CNAME
@@ -1658,6 +1670,13 @@ optic:
     values:
       - amazonses:brpgA+nYWbeXbq05BWkw0znt7qzeOXcRRork8ZaTJlQ=
       - v=spf1 include:spf.protection.outlook.com include:amazonses.com -all
+pay-by-account:
+  - ttl: 3600
+    type: MX
+    value: paybyaccount-justice-gov-uk0ie.mail.protection.outlook.com.
+  - ttl: 3600
+    type: TXT
+    value: v=spf1 include:spf.protection.outlook.com -all
 pcjuq4p5sm3aixid6ygchuzdzgafb4k3._domainkey.internaltest.ppud:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
This pull request adds DNS records for the new "pay-by-account" subdomain. The changes ensure that email and service auto-discovery for "pay-by-account" are properly configured for Microsoft services.

New DNS records for "pay-by-account":

**Auto-discovery and enrollment configuration:**
- Added `autodiscover.pay-by-account` as a CNAME pointing to `autodiscover.outlook.com.` for Outlook auto-discovery.
- Added `enterpriseenrollment.pay-by-account` as a CNAME pointing to `enterpriseenrollment-s.manage.microsoft.com.` for Microsoft device enrollment.
- Added `enterpriseregistration.pay-by-account` as a CNAME pointing to `enterpriseregistration.windows.net.` for device registration.

**Email configuration:**
- Added MX and SPF TXT records under `pay-by-account` to route email through Outlook and specify allowed senders.