### PR TITLE
Add brevo related email subdomains to yjresourcehub.uk

### DIFF
--- a/hostedzones/yjresourcehub.uk.yaml
+++ b/hostedzones/yjresourcehub.uk.yaml
@@ -12,6 +12,11 @@
     values:
       - 162.159.136.54
       - 162.159.137.54
+  - ttl: 300
+    type: TXT
+    value2:
+      - v=spf1 include:spf.brevo.com ~all
+      - brevo-code:f053f16ebd5efa0b339517a4522baaac
 _asvdns-b00d86d0-bca4-47aa-9475-64cbe5e0387e:
   ttl: 300
   type: TXT
@@ -20,6 +25,18 @@ _cf-custom-hostname:
   ttl: 300
   type: TXT
   value: 18907e81-b8ad-4064-8255-97a098f4d61d
+_dmarc:
+  ttl: 300
+  type: TXT
+  value: v=DMARC1; p=none; rua=mailto:rua@dmarc.brevo.com
+brevo1._domainkey:
+  ttl: 300
+  type: CNAME
+  value: b1.yjresourcehub-uk.dkim.brevo.com.
+brevo2._domainkey:
+  ttl: 300
+  type: CNAME
+  value: b2.yjresourcehub-uk.dkim.brevo.com.
 em7378:
   ttl: 1800
   type: CNAME
@@ -35,4 +52,4 @@ s2._domainkey:
 www:
   ttl: 300
   type: CNAME
-  value: yjresourcehub.uk
+  value: yjresourcehub.uk.


### PR DESCRIPTION
This pull request updates DNS records in the `hostedzones/yjresourcehub.uk.yaml` file to improve email authentication and correct a CNAME record. The most important changes are the addition of SPF, DMARC, and DKIM records for Brevo email services, and a minor fix to the `www` CNAME record.

**Email authentication improvements:**

* Added a new TXT record for SPF to authorize Brevo as a sender and included a Brevo verification code.
* Added a DMARC TXT record to specify DMARC policy and reporting address.
* Added two CNAME records (`brevo1._domainkey` and `brevo2._domainkey`) for DKIM to enable Brevo DKIM signing.

**DNS record correction:**

* Fixed the `www` CNAME record by adding a trailing dot to the target, ensuring proper DNS resolution.