### PR TITLE
Remove delegation for laa-status-dashboard

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -1070,14 +1070,6 @@ laa-sign-in.external-identity:
   ttl: 300
   type: CNAME
   value: afd-endpoint-eucs-entra-ext-activation-003-adejdchyaehah4a9.a02.azurefd.net
-laa-status-dashboard:
-  ttl: 300
-  type: NS
-  values:
-    - ns-1144.awsdns-15.org.
-    - ns-1723.awsdns-23.co.uk.
-    - ns-209.awsdns-26.com.
-    - ns-925.awsdns-51.net.
 legacy.manage-external-funded-offender-provision:
   ttl: 300
   type: CNAME


### PR DESCRIPTION
This pull request removes the DNS record for `laa-status-dashboard` from the `hostedzones/service.justice.gov.uk.yaml` file. 

Application has been decommissioned so delegation can be removed.

* Removed the `laa-status-dashboard` NS (Name Server) record