### PR TITLE
Delete dev.developer-portal.service.justice.gov.uk.yaml

### DIFF
--- a/hostedzones/service.justice.gov.uk.yaml
+++ b/hostedzones/service.justice.gov.uk.yaml
@@ -697,14 +697,6 @@ design-patterns:
     - ns-1918.awsdns-47.co.uk.
     - ns-208.awsdns-26.com.
     - ns-836.awsdns-40.net.
-dev.developer-portal:
-  ttl: 300
-  type: NS
-  values:
-    - ns-1230.awsdns-25.org.
-    - ns-1738.awsdns-25.co.uk.
-    - ns-228.awsdns-28.com.
-    - ns-835.awsdns-40.net.
 dev.manage-external-funded-offender-provision:
   ttl: 942942942
   type: Route53Provider/ALIAS


### PR DESCRIPTION
PR removes `dev.developer-portal.service.justice.gov.uk`. As the parent domain is delegated, this NS record isn't required.